### PR TITLE
Update thread model

### DIFF
--- a/cluster/src/main/java/io/scalecube/cluster/Cluster.java
+++ b/cluster/src/main/java/io/scalecube/cluster/Cluster.java
@@ -19,10 +19,8 @@ import org.slf4j.LoggerFactory;
 
 import rx.Observable;
 import rx.Scheduler;
-import rx.schedulers.Schedulers;
 
 import java.util.UUID;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -163,11 +161,6 @@ public final class Cluster implements ICluster {
   }
 
   @Override
-  public Observable<Message> listen(Executor executor) {
-    return listen(Schedulers.from(executor));
-  }
-
-  @Override
   public Observable<Message> listen(Scheduler scheduler) {
     return listen().observeOn(scheduler);
   }
@@ -180,11 +173,6 @@ public final class Cluster implements ICluster {
   @Override
   public Observable<Message> listenGossips() {
     return gossipProtocol.listen();
-  }
-
-  @Override
-  public Observable<Message> listenGossips(Executor executor) {
-    return listenGossips(Schedulers.from(executor));
   }
 
   @Override

--- a/cluster/src/main/java/io/scalecube/cluster/Cluster.java
+++ b/cluster/src/main/java/io/scalecube/cluster/Cluster.java
@@ -5,7 +5,6 @@ import static com.google.common.util.concurrent.Futures.transform;
 
 import io.scalecube.cluster.fdetector.FailureDetector;
 import io.scalecube.cluster.gossip.GossipProtocol;
-import io.scalecube.cluster.gossip.IGossipProtocol;
 import io.scalecube.transport.Message;
 import io.scalecube.transport.Transport;
 
@@ -19,8 +18,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
 
 import java.util.UUID;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -161,6 +163,16 @@ public final class Cluster implements ICluster {
   }
 
   @Override
+  public Observable<Message> listen(Executor executor) {
+    return listen(Schedulers.from(executor));
+  }
+
+  @Override
+  public Observable<Message> listen(Scheduler scheduler) {
+    return listen().observeOn(scheduler);
+  }
+
+  @Override
   public void spreadGossip(Message message) {
     gossipProtocol.spread(message);
   }
@@ -168,6 +180,16 @@ public final class Cluster implements ICluster {
   @Override
   public Observable<Message> listenGossips() {
     return gossipProtocol.listen();
+  }
+
+  @Override
+  public Observable<Message> listenGossips(Executor executor) {
+    return listenGossips(Schedulers.from(executor));
+  }
+
+  @Override
+  public Observable<Message> listenGossips(Scheduler scheduler) {
+    return listenGossips().observeOn(scheduler);
   }
 
   @Override

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterMembership.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterMembership.java
@@ -47,7 +47,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -183,11 +182,6 @@ public final class ClusterMembership implements IClusterMembership {
   @Override
   public Observable<ClusterMember> listen() {
     return subject;
-  }
-
-  @Override
-  public Observable<ClusterMember> listen(Executor executor) {
-    return listen(Schedulers.from(executor));
   }
 
   @Override

--- a/cluster/src/main/java/io/scalecube/cluster/ICluster.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ICluster.java
@@ -1,34 +1,48 @@
 package io.scalecube.cluster;
 
-import io.scalecube.cluster.gossip.IGossipProtocol;
+import io.scalecube.transport.IListenable;
 import io.scalecube.transport.Message;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
 import rx.Observable;
+import rx.Scheduler;
+
+import java.util.concurrent.Executor;
 
 /**
  * Basic cluster interface which allows to join cluster, send message to other member, listen messages, gossip messages.
  * 
  * @author Anton Kharenko
  */
-public interface ICluster {
-
-  void send(ClusterMember member, Message message);
-
-  void send(ClusterMember member, Message message, SettableFuture<Void> promise);
-
-  Observable<Message> listen();
-
-  /** Spreads given message between cluster members. */
-  void spreadGossip(Message message);
-
-  /** Listens for gossips from other cluster members. */
-  Observable<Message> listenGossips();
+public interface ICluster extends IListenable<Message> {
 
   IClusterMembership membership();
 
   ListenableFuture<Void> leave();
 
+  void send(ClusterMember member, Message message);
+
+  void send(ClusterMember member, Message message, SettableFuture<Void> promise);
+
+  /**
+   * Spreads given message between cluster members.
+   */
+  void spreadGossip(Message message);
+
+  /**
+   * Listens for gossips from other cluster members.
+   */
+  Observable<Message> listenGossips();
+
+  /**
+   * Listens for gossips from other cluster members.
+   */
+  Observable<Message> listenGossips(Executor executor);
+
+  /**
+   * Listens for gossips from other cluster members.
+   */
+  Observable<Message> listenGossips(Scheduler scheduler);
 }

--- a/cluster/src/main/java/io/scalecube/cluster/ICluster.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ICluster.java
@@ -9,8 +9,6 @@ import com.google.common.util.concurrent.SettableFuture;
 import rx.Observable;
 import rx.Scheduler;
 
-import java.util.concurrent.Executor;
-
 /**
  * Basic cluster interface which allows to join cluster, send message to other member, listen messages, gossip messages.
  * 
@@ -35,11 +33,6 @@ public interface ICluster extends IListenable<Message> {
    * Listens for gossips from other cluster members.
    */
   Observable<Message> listenGossips();
-
-  /**
-   * Listens for gossips from other cluster members.
-   */
-  Observable<Message> listenGossips(Executor executor);
 
   /**
    * Listens for gossips from other cluster members.

--- a/cluster/src/main/java/io/scalecube/cluster/IClusterMembership.java
+++ b/cluster/src/main/java/io/scalecube/cluster/IClusterMembership.java
@@ -1,32 +1,40 @@
 package io.scalecube.cluster;
 
 import io.scalecube.transport.Address;
+import io.scalecube.transport.IListenable;
 
 import rx.Observable;
+import rx.Scheduler;
 
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * Cluster Membership Protocol component responsible for managing information about existing members of the cluster.
  *
  * @author Anton Kharenko
  */
-public interface IClusterMembership {
+public interface IClusterMembership extends IListenable<ClusterMember> {
 
-  /** Returns current cluster members list. */
+  /**
+   * Returns current cluster members list.
+   */
   List<ClusterMember> members();
 
-  /** Returns cluster member by its id or null if no member with such id exists. */
+  /**
+   * Returns cluster member by its id or null if no member with such id exists.
+   */
   ClusterMember member(String id);
 
-  /** Returns cluster member by its address or null if no member with such address exists. */
+  /**
+   * Returns cluster member by its address or null if no member with such address exists.
+   */
   ClusterMember member(Address address);
 
-  /** Returns local cluster member. */
+  /**
+   * Returns local cluster member.
+   */
   ClusterMember localMember();
-
-  /** Listen status updates on registered cluster members (except local one). */
-  Observable<ClusterMember> listen();
 
   /**
    * Check if a given member is a local member return true in case the ClusterMember is local to the cluster instance.
@@ -36,4 +44,21 @@ public interface IClusterMembership {
    */
   boolean isLocalMember(ClusterMember member);
 
+  /**
+   * Listen status updates on registered cluster members (except local one).
+   */
+  @Override
+  Observable<ClusterMember> listen();
+
+  /**
+   * Listen status updates on registered cluster members (except local one).
+   */
+  @Override
+  Observable<ClusterMember> listen(Executor executor);
+
+  /**
+   * Listen status updates on registered cluster members (except local one).
+   */
+  @Override
+  Observable<ClusterMember> listen(Scheduler scheduler);
 }

--- a/cluster/src/main/java/io/scalecube/cluster/IClusterMembership.java
+++ b/cluster/src/main/java/io/scalecube/cluster/IClusterMembership.java
@@ -26,7 +26,7 @@ public interface IClusterMembership {
   ClusterMember localMember();
 
   /** Listen status updates on registered cluster members (except local one). */
-  Observable<ClusterMember> listenUpdates();
+  Observable<ClusterMember> listen();
 
   /**
    * Check if a given member is a local member return true in case the ClusterMember is local to the cluster instance.

--- a/cluster/src/main/java/io/scalecube/cluster/IClusterMembership.java
+++ b/cluster/src/main/java/io/scalecube/cluster/IClusterMembership.java
@@ -7,7 +7,6 @@ import rx.Observable;
 import rx.Scheduler;
 
 import java.util.List;
-import java.util.concurrent.Executor;
 
 /**
  * Cluster Membership Protocol component responsible for managing information about existing members of the cluster.
@@ -49,12 +48,6 @@ public interface IClusterMembership extends IListenable<ClusterMember> {
    */
   @Override
   Observable<ClusterMember> listen();
-
-  /**
-   * Listen status updates on registered cluster members (except local one).
-   */
-  @Override
-  Observable<ClusterMember> listen(Executor executor);
 
   /**
    * Listen status updates on registered cluster members (except local one).

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
@@ -24,7 +24,6 @@ import rx.functions.Func1;
 import rx.observers.Subscribers;
 import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
-import rx.subjects.SerializedSubject;
 import rx.subjects.Subject;
 
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public final class FailureDetector implements IFailureDetector {
   private static final Logger LOGGER = LoggerFactory.getLogger(FailureDetector.class);
@@ -66,8 +64,8 @@ public final class FailureDetector implements IFailureDetector {
 
   // State
 
+  private long period = 0;
   private volatile List<Address> members = new ArrayList<>();
-  private final AtomicInteger periodCounter = new AtomicInteger();
   private Set<Address> suspectedMembers = Sets.newConcurrentHashSet();
 
   // Subscriptions
@@ -75,8 +73,7 @@ public final class FailureDetector implements IFailureDetector {
   private Subscriber<Message> onPingRequestSubscriber;
   private Subscriber<Message> onAskToPingRequestSubscriber;
   private Subscriber<Message> onTransitAckRequestSubscriber;
-  private Subject<FailureDetectorEvent, FailureDetectorEvent> subject =
-      new SerializedSubject<>(PublishSubject.<FailureDetectorEvent>create());
+  private Subject<FailureDetectorEvent, FailureDetectorEvent> subject = PublishSubject.create();
 
   // Scheduled
 
@@ -127,17 +124,20 @@ public final class FailureDetector implements IFailureDetector {
   public void start() {
     onPingRequestSubscriber = Subscribers.create(new OnPingRequestAction());
     transport.listen()
+        .observeOn(scheduler)
         .filter(PING_FILTER)
         .filter(targetFilter(transport.address()))
         .subscribe(onPingRequestSubscriber);
 
     onAskToPingRequestSubscriber = Subscribers.create(new OnAskToPingRequestAction());
     transport.listen()
+        .observeOn(scheduler)
         .filter(PING_REQ_FILTER)
         .subscribe(onAskToPingRequestSubscriber);
 
     onTransitAckRequestSubscriber = Subscribers.create(new OnTransitAckRequestAction());
     transport.listen()
+        .observeOn(scheduler)
         .filter(ACK_FILTER)
         .filter(ORIGINAL_ISSUER_FILTER)
         .subscribe(onTransitAckRequestSubscriber);
@@ -167,7 +167,7 @@ public final class FailureDetector implements IFailureDetector {
   }
 
   @Override
-  public Observable<FailureDetectorEvent> listenStatus() {
+  public Observable<FailureDetectorEvent> listen() {
     return subject;
   }
 
@@ -194,13 +194,14 @@ public final class FailureDetector implements IFailureDetector {
     }
 
     final Address localAddress = transport.address();
-    final String period = Integer.toString(periodCounter.incrementAndGet());
+    final String cid = Long.toString(this.period);
     PingData pingData = new PingData(localAddress, pingMember);
-    Message pingMsg = Message.withData(pingData).qualifier(PING).correlationId(period).build();
+    Message pingMsg = Message.withData(pingData).qualifier(PING).correlationId(cid).build();
     LOGGER.trace("Send Ping from {} to {}", localAddress, pingMember);
 
     transport.listen()
-        .filter(ackFilter(period))
+        .observeOn(scheduler)
+        .filter(ackFilter(cid))
         .filter(new CorrelationFilter(localAddress, pingMember))
         .take(1)
         .timeout(config.getPingTimeout(), TimeUnit.MILLISECONDS, scheduler)
@@ -215,14 +216,14 @@ public final class FailureDetector implements IFailureDetector {
           public void call(Throwable throwable) {
             LOGGER.trace("No PingAck from {} within {}ms; about to make PingReq now",
                 pingMember, config.getPingTimeout());
-            doPingReq(pingMember, period);
+            doPingReq(pingMember, cid);
           }
         }));
 
     transport.send(pingMember, pingMsg);
   }
 
-  private void doPingReq(final Address pingMember, String period) {
+  private void doPingReq(final Address pingMember, String cid) {
     final int timeout = config.getPingTime() - config.getPingTimeout();
     if (timeout <= 0) {
       LOGGER.trace("No PingReq occurred, because no time left (pingTime={}, pingTimeout={})",
@@ -240,7 +241,8 @@ public final class FailureDetector implements IFailureDetector {
 
     Address localAddress = transport.address();
     transport.listen()
-        .filter(ackFilter(period))
+        .observeOn(scheduler)
+        .filter(ackFilter(cid))
         .filter(new CorrelationFilter(localAddress, pingMember))
         .take(1)
         .timeout(timeout, TimeUnit.MILLISECONDS, scheduler)
@@ -260,7 +262,7 @@ public final class FailureDetector implements IFailureDetector {
         }));
 
     PingData pingReqData = new PingData(localAddress, pingMember);
-    Message pingReqMsg = Message.withData(pingReqData).qualifier(PING_REQ).correlationId(period).build();
+    Message pingReqMsg = Message.withData(pingReqData).qualifier(PING_REQ).correlationId(cid).build();
     for (Address pingReqMember : pingReqMembers) {
       LOGGER.trace("Send PingReq from {} to {}", localAddress, pingReqMember);
       transport.send(pingReqMember, pingReqMsg);
@@ -387,6 +389,7 @@ public final class FailureDetector implements IFailureDetector {
     @Override
     public void run() {
       try {
+        period++;
         doPing();
       } catch (Exception cause) {
         LOGGER.error("Unhandled exception: {}", cause, cause);

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -167,11 +166,6 @@ public final class FailureDetector implements IFailureDetector {
   @Override
   public Observable<FailureDetectorEvent> listen() {
     return subject;
-  }
-
-  @Override
-  public Observable<FailureDetectorEvent> listen(Executor executor) {
-    return listen(Schedulers.from(executor));
   }
 
   @Override

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/IFailureDetector.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/IFailureDetector.java
@@ -7,7 +7,6 @@ import rx.Observable;
 import rx.Scheduler;
 
 import java.util.Collection;
-import java.util.concurrent.Executor;
 
 /**
  * Failure Detector component responsible for monitoring availability of other members in the cluster. This interface is
@@ -49,12 +48,6 @@ public interface IFailureDetector extends IListenable<FailureDetectorEvent> {
    */
   @Override
   Observable<FailureDetectorEvent> listen();
-
-  /**
-   * Listens for detected cluster members status changes (SUSPECTED/TRUSTED).
-   */
-  @Override
-  Observable<FailureDetectorEvent> listen(Executor executor);
 
   /**
    * Listens for detected cluster members status changes (SUSPECTED/TRUSTED).

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/IFailureDetector.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/IFailureDetector.java
@@ -25,7 +25,7 @@ public interface IFailureDetector {
   void stop();
 
   /** Listens for detected cluster members status changes (SUSPECTED/TRUSTED) by failure detector. */
-  Observable<FailureDetectorEvent> listenStatus();
+  Observable<FailureDetectorEvent> listen();
 
   /** Marks given member as SUSPECTED inside FD algorithm internals. */
   void suspect(Address member);

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/IFailureDetector.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/IFailureDetector.java
@@ -1,10 +1,13 @@
 package io.scalecube.cluster.fdetector;
 
 import io.scalecube.transport.Address;
+import io.scalecube.transport.IListenable;
 
 import rx.Observable;
+import rx.Scheduler;
 
 import java.util.Collection;
+import java.util.concurrent.Executor;
 
 /**
  * Failure Detector component responsible for monitoring availability of other members in the cluster. This interface is
@@ -14,25 +17,48 @@ import java.util.Collection;
  *
  * @author Anton Kharenko
  */
-public interface IFailureDetector {
+public interface IFailureDetector extends IListenable<FailureDetectorEvent> {
 
   /**
    * Starts running failure detection algorithm. After started it begins to receive and send ping messages.
    */
   void start();
 
-  /** Stops running failure detection algorithm and releases occupied resources. */
+  /**
+   * Stops running failure detection algorithm and releases occupied resources.
+   */
   void stop();
 
-  /** Listens for detected cluster members status changes (SUSPECTED/TRUSTED) by failure detector. */
-  Observable<FailureDetectorEvent> listen();
-
-  /** Marks given member as SUSPECTED inside FD algorithm internals. */
+  /**
+   * Marks given member as SUSPECTED inside FD algorithm internals.
+   */
   void suspect(Address member);
 
-  /** Marks given member as TRUSTED inside FD algorithm internals. */
+  /**
+   * Marks given member as TRUSTED inside FD algorithm internals.
+   */
   void trust(Address member);
 
-  /** Updates list of cluster members among which should work FD algorithm. */
+  /**
+   * Updates list of cluster members among which should work FD algorithm.
+   */
   void setMembers(Collection<Address> members);
+
+  /**
+   * Listens for detected cluster members status changes (SUSPECTED/TRUSTED).
+   */
+  @Override
+  Observable<FailureDetectorEvent> listen();
+
+  /**
+   * Listens for detected cluster members status changes (SUSPECTED/TRUSTED).
+   */
+  @Override
+  Observable<FailureDetectorEvent> listen(Executor executor);
+
+  /**
+   * Listens for detected cluster members status changes (SUSPECTED/TRUSTED).
+   */
+  @Override
+  Observable<FailureDetectorEvent> listen(Scheduler scheduler);
 }

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -151,11 +150,6 @@ public final class GossipProtocol implements IGossipProtocol {
   @Override
   public Observable<Message> listen() {
     return subject;
-  }
-
-  @Override
-  public Observable<Message> listen(Executor executor) {
-    return listen(Schedulers.from(executor));
   }
 
   @Override

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -118,7 +119,7 @@ public final class GossipProtocol implements IGossipProtocol {
   @Override
   public void start() {
     onGossipRequestSubscriber = Subscribers.create(new OnGossipRequestAction(gossipsQueue));
-    transport.listen().observeOn(scheduler).filter(new GossipMessageFilter()).subscribe(onGossipRequestSubscriber);
+    transport.listen(scheduler).filter(new GossipMessageFilter()).subscribe(onGossipRequestSubscriber);
 
     int gossipTime = config.getGossipTime();
     executorTask =
@@ -150,6 +151,16 @@ public final class GossipProtocol implements IGossipProtocol {
   @Override
   public Observable<Message> listen() {
     return subject;
+  }
+
+  @Override
+  public Observable<Message> listen(Executor executor) {
+    return listen(Schedulers.from(executor));
+  }
+
+  @Override
+  public Observable<Message> listen(Scheduler scheduler) {
+    return listen().observeOn(scheduler);
   }
 
   private Collection<GossipLocalState> processGossipQueue() {

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/IGossipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/IGossipProtocol.java
@@ -8,7 +8,6 @@ import rx.Observable;
 import rx.Scheduler;
 
 import java.util.Collection;
-import java.util.concurrent.Executor;
 
 /**
  * Gossip Protocol component responsible for spreading information (gossips) over the cluster members using
@@ -43,12 +42,6 @@ public interface IGossipProtocol extends IListenable<Message> {
    */
   @Override
   Observable<Message> listen();
-
-  /**
-   * Listens for gossips from other cluster members.
-   */
-  @Override
-  Observable<Message> listen(Executor executor);
 
   /**
    * Listens for gossips from other cluster members.

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/IGossipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/IGossipProtocol.java
@@ -1,11 +1,14 @@
 package io.scalecube.cluster.gossip;
 
 import io.scalecube.transport.Address;
+import io.scalecube.transport.IListenable;
 import io.scalecube.transport.Message;
 
 import rx.Observable;
+import rx.Scheduler;
 
 import java.util.Collection;
+import java.util.concurrent.Executor;
 
 /**
  * Gossip Protocol component responsible for spreading information (gossips) over the cluster members using
@@ -13,21 +16,43 @@ import java.util.Collection;
  *
  * @author Anton Kharenko
  */
-public interface IGossipProtocol {
+public interface IGossipProtocol extends IListenable<Message> {
 
-  /** Starts running gossip protocol. After started it begins to receive and send gossip messages */
+  /**
+   * Starts running gossip protocol. After started it begins to receive and send gossip messages.
+   */
   void start();
 
-  /** Stops running gossip protocol and releases occupied resources. */
+  /**
+   * Stops running gossip protocol and releases occupied resources.
+   */
   void stop();
 
-  /** Spreads given message between cluster members. */
+  /**
+   * Spreads given message between cluster members.
+   */
   void spread(Message message);
 
-  /** Listens for gossips from other cluster members. */
-  Observable<Message> listen();
-
-  /** Updates list of cluster members among which should be spread gossips. */
+  /**
+   * Updates list of cluster members among which should be spread gossips.
+   */
   void setMembers(Collection<Address> members);
 
+  /**
+   * Listens for gossips from other cluster members.
+   */
+  @Override
+  Observable<Message> listen();
+
+  /**
+   * Listens for gossips from other cluster members.
+   */
+  @Override
+  Observable<Message> listen(Executor executor);
+
+  /**
+   * Listens for gossips from other cluster members.
+   */
+  @Override
+  Observable<Message> listen(Scheduler scheduler);
 }

--- a/transport/src/main/java/io/scalecube/transport/BootstrapFactory.java
+++ b/transport/src/main/java/io/scalecube/transport/BootstrapFactory.java
@@ -103,10 +103,6 @@ final class BootstrapFactory {
     return envSupportEpoll && config.isEnableEpoll();
   }
 
-  public EventLoopGroup getWorkerGroup() {
-    return workerGroup;
-  }
-
   public void shutdown() {
     this.bossGroup.shutdownGracefully();
     this.workerGroup.shutdownGracefully();

--- a/transport/src/main/java/io/scalecube/transport/IListenable.java
+++ b/transport/src/main/java/io/scalecube/transport/IListenable.java
@@ -1,0 +1,15 @@
+package io.scalecube.transport;
+
+import rx.Observable;
+import rx.Scheduler;
+
+import java.util.concurrent.Executor;
+
+public interface IListenable<T> {
+
+  Observable<T> listen();
+
+  Observable<T> listen(Executor executor);
+
+  Observable<T> listen(Scheduler scheduler);
+}

--- a/transport/src/main/java/io/scalecube/transport/IListenable.java
+++ b/transport/src/main/java/io/scalecube/transport/IListenable.java
@@ -3,13 +3,9 @@ package io.scalecube.transport;
 import rx.Observable;
 import rx.Scheduler;
 
-import java.util.concurrent.Executor;
-
 public interface IListenable<T> {
 
   Observable<T> listen();
-
-  Observable<T> listen(Executor executor);
 
   Observable<T> listen(Scheduler scheduler);
 }

--- a/transport/src/main/java/io/scalecube/transport/ITransport.java
+++ b/transport/src/main/java/io/scalecube/transport/ITransport.java
@@ -2,7 +2,11 @@ package io.scalecube.transport;
 
 import com.google.common.util.concurrent.SettableFuture;
 
+import rx.Observable;
+import rx.Scheduler;
+
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -54,4 +58,32 @@ public interface ITransport extends IListenable<Message> {
    * @throws IllegalArgumentException if {@code message} or {@code address} is null
    */
   void send(@CheckForNull Address address, @CheckForNull Message message, @Nullable SettableFuture<Void> promise);
+
+  /**
+   * Returns stream of received messages. For each observers subscribed to the returned observable:
+   * <ul>
+   * <li>{@code rx.Observer#onNext(Object)} will be invoked when some message arrived to current transport</li>
+   * <li>{@code rx.Observer#onCompleted()} will be invoked when there is no possibility that server will receive new
+   * message observable for already closed transport</li>
+   * <li>{@code rx.Observer#onError(Throwable)} will not be invoked</li>
+   * </ul>
+   *
+   * @return Observable which emit received messages or complete event when transport is closed
+   */
+  @Nonnull
+  Observable<Message> listen();
+
+  /**
+   * Returns stream of received messages. For each observers subscribed to the returned observable:
+   * <ul>
+   * <li>{@code rx.Observer#onNext(Object)} will be invoked when some message arrived to current transport</li>
+   * <li>{@code rx.Observer#onCompleted()} will be invoked when there is no possibility that server will receive new
+   * message observable for already closed transport</li>
+   * <li>{@code rx.Observer#onError(Throwable)} will not be invoked</li>
+   * </ul>
+   *
+   * @return Observable which emit received messages or complete event when transport is closed
+   */
+  @Nonnull
+  Observable<Message> listen(Scheduler scheduler);
 }

--- a/transport/src/main/java/io/scalecube/transport/ITransport.java
+++ b/transport/src/main/java/io/scalecube/transport/ITransport.java
@@ -1,19 +1,15 @@
 package io.scalecube.transport;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
-import rx.Observable;
-
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
- * Transport is responsible for maintaining existing p2p connections to/from other transports.
- * It allows sending messages and listen incoming messages.
+ * Transport is responsible for maintaining existing p2p connections to/from other transports. It allows sending
+ * messages and listen incoming messages.
  */
-public interface ITransport {
+public interface ITransport extends IListenable<Message> {
 
   /**
    * Returns local {@link Address} on which current instance of transport listens for incoming messages.
@@ -50,27 +46,12 @@ public interface ITransport {
 
   /**
    * Sends message to the given address. It will issue connect in case if no transport channel by given {@code address}
-   * exists already. Send is an async operation, if result of operation is not needed leave third
-   * parameter null, otherwise pass {@link SettableFuture}.
+   * exists already. Send is an async operation, if result of operation is not needed leave third parameter null,
+   * otherwise pass {@link SettableFuture}.
    *
    * @param message message to send
    * @param promise promise will be completed with result of sending (void or exception)
    * @throws IllegalArgumentException if {@code message} or {@code address} is null
    */
   void send(@CheckForNull Address address, @CheckForNull Message message, @Nullable SettableFuture<Void> promise);
-
-  /**
-   * Returns stream of received messages. For each observers subscribed to the returned observable:
-   * <ul>
-   * <li>{@code rx.Observer#onNext(Object)} will be invoked when some message arrived to current transport</li>
-   * <li>{@code rx.Observer#onCompleted()} will be invoked when there is no possibility that server will receive new
-   * message observable for already closed transport</li>
-   * <li>{@code rx.Observer#onError(Throwable)} will not be invoked</li>
-   * </ul>
-   *
-   * @return Observable which emit received messages or complete event when transport is closed
-   */
-  @Nonnull
-  Observable<Message> listen();
-
 }

--- a/transport/src/main/java/io/scalecube/transport/Transport.java
+++ b/transport/src/main/java/io/scalecube/transport/Transport.java
@@ -34,13 +34,11 @@ import org.slf4j.LoggerFactory;
 
 import rx.Observable;
 import rx.Scheduler;
-import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
 import java.net.InetAddress;
 import java.util.Collection;
-import java.util.concurrent.Executor;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
@@ -280,11 +278,6 @@ public final class Transport implements ITransport {
   public Observable<Message> listen() {
     checkState(!stopped, "Transport is stopped");
     return incomingMessagesSubject;
-  }
-
-  @Override
-  public Observable<Message> listen(Executor executor) {
-    return listen(Schedulers.from(executor));
   }
 
   @Override

--- a/transport/src/main/java/io/scalecube/transport/Transport.java
+++ b/transport/src/main/java/io/scalecube/transport/Transport.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import rx.Observable;
-import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
@@ -128,8 +127,6 @@ public final class Transport implements ITransport {
    * Starts to accept connections on local address.
    */
   private ListenableFuture<Transport> bind0() {
-    incomingMessagesSubject.subscribeOn(Schedulers.from(bootstrapFactory.getWorkerGroup()));
-
     // Resolve listen IP address
     final InetAddress listenAddress =
         Addressing.getLocalIpAddress(config.getListenAddress(), config.getListenInterface(), config.isPreferIPv6());

--- a/transport/src/main/java/io/scalecube/transport/Transport.java
+++ b/transport/src/main/java/io/scalecube/transport/Transport.java
@@ -33,14 +33,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 import rx.subjects.Subject;
 
 import java.net.InetAddress;
 import java.util.Collection;
+import java.util.concurrent.Executor;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public final class Transport implements ITransport {
@@ -274,11 +276,20 @@ public final class Transport implements ITransport {
     bootstrapFactory.shutdown();
   }
 
-  @Nonnull
   @Override
-  public final Observable<Message> listen() {
+  public Observable<Message> listen() {
     checkState(!stopped, "Transport is stopped");
     return incomingMessagesSubject;
+  }
+
+  @Override
+  public Observable<Message> listen(Executor executor) {
+    return listen(Schedulers.from(executor));
+  }
+
+  @Override
+  public Observable<Message> listen(Scheduler scheduler) {
+    return listen().observeOn(scheduler);
   }
 
   @Override


### PR DESCRIPTION
* Removed `` SerializedSubject`` from usages et al.
* Made all algorithms single threaded.
* Added ``IListenable`` interface so users could specify their own executors where to listen for events.
* Simplified code in ``ClustMembership `` regarding  scheduling removal of suspected member.