### PR TITLE
Add Support for service tags for Canary testing

### DIFF
--- a/examples/src/main/java/io/scalecube/examples/services/MicroservicesExample.java
+++ b/examples/src/main/java/io/scalecube/examples/services/MicroservicesExample.java
@@ -20,7 +20,7 @@ public class MicroservicesExample {
     Microservices provider = Microservices.builder()
         .services(new GreetingServiceImpl())
         .build();
-
+    System.out.println(provider.cluster().members());
     // Return provider address
     return provider.cluster().address();
   }
@@ -41,6 +41,8 @@ public class MicroservicesExample {
     CompletableFuture<String> futureError = greetingService.greetingException("Joe");
     futureError.whenComplete((result, exception) ->
         System.out.println("Consumer: 'greetingException' <- " + (exception == null ? result : exception)));
+    
+    System.out.println(consumer.cluster().members());
   }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <guava.version>19.0</guava.version>
         <findbugs.version>2.0.3</findbugs.version>
         <netty.version>4.0.40.Final</netty.version>
-        <protostuff.version>1.4.4</protostuff.version>
+        <protostuff.version>1.5.2</protostuff.version>
         <protobuf.version>2.4.1</protobuf.version>
     </properties>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>io.scalecube</groupId>
 		<artifactId>scalecube-parent</artifactId>
@@ -14,11 +15,17 @@
 	<dependencies>
 
 		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>scalecube-cluster</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/services/src/main/java/io/scalecube/services/ConfigAssist.java
+++ b/services/src/main/java/io/scalecube/services/ConfigAssist.java
@@ -16,10 +16,13 @@ public class ConfigAssist {
    * @param metadata provided metatadata requested in the config.
    * @return newly created ClusterConfig.
    */
-  public static ClusterConfig create(int port, Map<String, String> metadata) {
+  public static ClusterConfig create(String listenAddress, int port, boolean portAutoIncrement,
+      Map<String, String> metadata) {
     return ClusterConfig.builder()
         .transportConfig(
             TransportConfig.builder().port(port)
+                .listenAddress(listenAddress)
+                .portAutoIncrement(portAutoIncrement)
                 .build())
         .membershipConfig(MembershipConfig.builder()
             .metadata(metadata)
@@ -27,7 +30,8 @@ public class ConfigAssist {
         .build();
   }
 
-  public static ClusterConfig create() {
+  public static ClusterConfig create(String listenAddress, Integer port, boolean portAutoIncrement, Address[] seeds,
+      Map<String, String> metadata) {
     return ClusterConfig.builder().build();
   }
 
@@ -37,8 +41,12 @@ public class ConfigAssist {
    * @param metadata provided metatadata requested in the config.
    * @return newly created ClusterConfig.
    */
-  public static ClusterConfig create(Map<String, String> metadata) {
+  public static ClusterConfig create(String listenAddress, Map<String, String> metadata) {
     return ClusterConfig.builder()
+        .transportConfig(
+            TransportConfig.builder()
+                .listenAddress(listenAddress)
+                .build())
         .membershipConfig(MembershipConfig.builder()
             .metadata(metadata)
             .build())
@@ -52,8 +60,12 @@ public class ConfigAssist {
    * @param metadata provided metatadata requested in the config.
    * @return newly created ClusterConfig.
    */
-  public static ClusterConfig create(Address[] seeds, Map<String, String> metadata) {
+  public static ClusterConfig create(String listenAddress, Address[] seeds, Map<String, String> metadata) {
     return ClusterConfig.builder()
+        .transportConfig(
+            TransportConfig.builder()
+                .listenAddress(listenAddress)
+                .build())
         .membershipConfig(MembershipConfig.builder()
             .seedMembers(seeds)
             .metadata(metadata)
@@ -69,11 +81,14 @@ public class ConfigAssist {
    * @param metadata provided metatadata requested in the config.
    * @return newly created ClusterConfig.
    */
-  public static ClusterConfig create(int port, Address[] seeds, Map<String, String> metadata) {
+  public static ClusterConfig create(String listenAddress, int port, boolean portAutoIncrement, Address[] seeds,
+      Map<String, String> metadata) {
     return ClusterConfig.builder()
         .transportConfig(
             TransportConfig.builder()
+                .listenAddress(listenAddress)
                 .port(port)
+                .portAutoIncrement(portAutoIncrement)
                 .build())
         .membershipConfig(MembershipConfig.builder()
             .seedMembers(seeds)

--- a/services/src/main/java/io/scalecube/services/DispatchingFuture.java
+++ b/services/src/main/java/io/scalecube/services/DispatchingFuture.java
@@ -33,6 +33,7 @@ public class DispatchingFuture {
 
   /**
    * private contractor use static method from.
+   * 
    * @param cluster instance.
    * @param request original service request.
    */

--- a/services/src/main/java/io/scalecube/services/JsonUtil.java
+++ b/services/src/main/java/io/scalecube/services/JsonUtil.java
@@ -1,0 +1,36 @@
+package io.scalecube.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonUtil {
+
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  /**
+   * Create service Advertisement from a json format.
+   * 
+   * @param value json value of a registration info.
+   * @return instance of service Advertisement.
+   */
+  public static <T> T from(String value, Class<T> clazz) {
+    try {
+      return (T) mapper.readValue(value, clazz);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  /**
+   * Create json format of a service Advertisement.
+   * 
+   * @param value instance value of a Advertisement.
+   * @return json value of a registration info.
+   */
+  public static String toJson(Object value) {
+    try {
+      return mapper.writeValueAsString(value);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
@@ -46,7 +46,7 @@ public class LocalServiceInstance implements ServiceInstance {
     this.memberId = memberId;
     this.tags = toMap(tags);
   }
-  
+
   private Map<String, String> toMap(Tag[] tags) {
     return Arrays.stream(tags).map(tag -> tag)
         .collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue()));
@@ -95,7 +95,7 @@ public class LocalServiceInstance implements ServiceInstance {
   public Map<String, String> tags() {
     return tags;
   }
-  
+
   @Override
   public String toString() {
     return "LocalServiceInstance [serviceName=" + serviceName + ", memberId=" + memberId + ", tags=" + tags + "]";

--- a/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
@@ -5,7 +5,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import io.scalecube.transport.Message;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Local service instance invokes the service instance hosted on this local process.
@@ -18,6 +23,7 @@ public class LocalServiceInstance implements ServiceInstance {
   private final Map<String, Method> methods;
   private final String serviceName;
   private final String memberId;
+  private final Map<String, String> tags;
 
   /**
    * LocalServiceInstance instance constructor.
@@ -26,8 +32,10 @@ public class LocalServiceInstance implements ServiceInstance {
    * @param memberId the Cluster memberId of this instance.
    * @param serviceName the qualifier name of the service.
    * @param methods the java methods of the service.
+   * @param tags service tags of this instance.
    */
-  public LocalServiceInstance(Object serviceObject, String memberId, String serviceName, Map<String, Method> methods) {
+  public LocalServiceInstance(Object serviceObject, String memberId, String serviceName, Map<String, Method> methods,
+      Tag[] tags) {
     checkArgument(serviceObject != null);
     checkArgument(memberId != null);
     checkArgument(serviceName != null);
@@ -36,8 +44,13 @@ public class LocalServiceInstance implements ServiceInstance {
     this.serviceName = serviceName;
     this.methods = methods;
     this.memberId = memberId;
+    this.tags = toMap(tags);
   }
-
+  
+  private Map<String, String> toMap(Tag[] tags) {
+    return Arrays.stream(tags).map(tag -> tag)
+        .collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue()));
+  }
 
   @Override
   public Object invoke(Message message, ServiceDefinition definition) throws Exception {
@@ -79,7 +92,12 @@ public class LocalServiceInstance implements ServiceInstance {
   }
 
   @Override
+  public Map<String, String> tags() {
+    return tags;
+  }
+  
+  @Override
   public String toString() {
-    return "LocalServiceInstance [serviceObject=" + serviceObject + ", memberId=" + memberId + "]";
+    return "LocalServiceInstance [serviceName=" + serviceName + ", memberId=" + memberId + ", tags=" + tags + "]";
   }
 }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -16,12 +16,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * The ScaleCube-Services module enables to provision and consuming microservices in a cluster. ScaleCube-Services
@@ -108,9 +107,9 @@ public class Microservices {
 
   private final ServiceProxyFactory proxyFactory;
 
-  private Microservices(ICluster cluster, Object[] services, boolean isSeed) {
+  private Microservices(ICluster cluster, ServiceConfig serviceConfig, boolean isSeed) {
     this.cluster = cluster;
-    this.serviceRegistry = new ServiceRegistryImpl(cluster, services, serviceProcessor, isSeed);
+    this.serviceRegistry = new ServiceRegistryImpl(cluster, serviceConfig, serviceProcessor, isSeed);
     this.proxyFactory = new ServiceProxyFactory(serviceRegistry, serviceProcessor);
     new ServiceDispatcher(cluster, serviceRegistry);
     this.cluster.listen().subscribe(message -> handleReply(message));
@@ -154,6 +153,7 @@ public class Microservices {
     private Integer port = null;
     private Address[] seeds;
     private Object[] services = new Object[0];
+    private ServiceConfig serviceConfig;
 
     /**
      * microsrrvices instance builder.
@@ -161,15 +161,24 @@ public class Microservices {
      * @return Microservices instance.
      */
     public Microservices build() {
+      if (serviceConfig != null && !serviceConfig.services().isEmpty() && services.length > 0) {
+        throw new IllegalStateException(
+            "ServiceConfig builder and services() are not allowed to be used in parallel."
+                + "please choose ServiceConfig builder in case you wish to register services with service tags");
+      }
+
+      if (serviceConfig == null) {
+        serviceConfig = ServiceConfig.from(services);
+      }
       ClusterConfig cfg = getClusterConfig();
-      return new Microservices(Cluster.joinAwait(cfg), services, seeds == null);
+      return new Microservices(Cluster.joinAwait(cfg), serviceConfig, seeds == null);
     }
 
     private ClusterConfig getClusterConfig() {
       Map<String, String> metadata = new HashMap<>();
 
-      if (services.length > 0) {
-        metadata = Microservices.metadata(services);
+      if (!serviceConfig.services().isEmpty()) {
+        metadata = Microservices.metadata(serviceConfig);
       }
 
       ClusterConfig cfg;
@@ -203,9 +212,22 @@ public class Microservices {
      */
     public Builder services(Object... services) {
       checkNotNull(services);
+
       if (services != null) {
         this.services = services;
       }
+      return this;
+    }
+
+    /**
+     * Services list to be registered.
+     * 
+     * @param services list of instances decorated with @Service
+     * @return builder.
+     */
+    public Builder services(ServiceConfig serviceConfig) {
+      checkNotNull(serviceConfig);
+      this.serviceConfig = serviceConfig;
       return this;
     }
   }
@@ -255,11 +277,18 @@ public class Microservices {
     }
   }
 
-  private static Map<String, String> metadata(Object... services) {
-    return Arrays.stream(services).flatMap(service -> {
-      Collection<Class<?>> serviceInterfaces = serviceProcessor.extractServiceInterfaces(service);
-      return serviceInterfaces.stream().map(serviceProcessor::introspectServiceInterface);
-    }).collect(Collectors.toMap(ServiceDefinition::serviceName,def -> "service"));
+  private static Map<String, String> metadata(ServiceConfig config) {
+    Map<String, String> result = new HashMap<>();
+
+    config.services().stream().forEach(service -> {
+      Collection<Class<?>> serviceInterfaces = serviceProcessor.extractServiceInterfaces(service.getService());
+      for (Class<?> serviceInterface : serviceInterfaces) {
+        ServiceDefinition def = serviceProcessor.introspectServiceInterface(serviceInterface);
+        result.put(ServiceInfo.toJson(def.serviceName(), service.getTags()), "service");
+      }
+    });
+
+    return Collections.unmodifiableMap(result);
   }
 
 }

--- a/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
@@ -1,8 +1,5 @@
 package io.scalecube.services;
 
-import static io.scalecube.services.ServiceHeaders.service_method_of;
-import static io.scalecube.services.ServiceHeaders.service_request_of;
-
 import static com.google.common.base.Preconditions.checkArgument;
 
 import io.scalecube.cluster.ICluster;
@@ -15,9 +12,14 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class RemoteServiceInstance implements ServiceInstance {
   private static final Logger LOGGER = LoggerFactory.getLogger(RemoteServiceInstance.class);
@@ -27,6 +29,8 @@ public class RemoteServiceInstance implements ServiceInstance {
   private final String memberId;
   private final String serviceName;
 
+  private final Map<String,String> tags;
+
 
   /**
    * Remote service instance constructor to initiate instance.
@@ -34,12 +38,20 @@ public class RemoteServiceInstance implements ServiceInstance {
    * @param cluster to be used for instance context.
    * @param serviceReference service reference of this instance.
    */
-  public RemoteServiceInstance(ICluster cluster, ServiceReference serviceReference) {
+  public RemoteServiceInstance(ICluster cluster, ServiceReference serviceReference,Tag[] tags) {
     this.serviceName = serviceReference.serviceName();
     this.cluster = cluster;
     this.address = serviceReference.address();
     this.memberId = serviceReference.memberId();
+    
+    this.tags = toMap(tags);
   }
+
+  private Map<String, String> toMap(Tag[] tags) {
+    return Arrays.stream(tags).map(tag -> tag)
+        .collect(Collectors.toMap(tag -> tag.getKey(), tag -> tag.getValue()));
+  }
+
 
   @Override
   public String serviceName() {
@@ -139,8 +151,12 @@ public class RemoteServiceInstance implements ServiceInstance {
 
   @Override
   public String toString() {
-    return "RemoteServiceInstance [address=" + address
-        + ", memberId=" + memberId
-        + "]";
+    return "RemoteServiceInstance [address=" + address + ", memberId=" + memberId + ", serviceName=" + serviceName
+        + ", tags=" + tags + "]";
+  }
+
+  @Override
+  public Map<String, String> tags() {
+    return tags;
   }
 }

--- a/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
@@ -29,7 +29,7 @@ public class RemoteServiceInstance implements ServiceInstance {
   private final String memberId;
   private final String serviceName;
 
-  private final Map<String,String> tags;
+  private final Map<String, String> tags;
 
 
   /**
@@ -38,12 +38,12 @@ public class RemoteServiceInstance implements ServiceInstance {
    * @param cluster to be used for instance context.
    * @param serviceReference service reference of this instance.
    */
-  public RemoteServiceInstance(ICluster cluster, ServiceReference serviceReference,Tag[] tags) {
+  public RemoteServiceInstance(ICluster cluster, ServiceReference serviceReference, Tag[] tags) {
     this.serviceName = serviceReference.serviceName();
     this.cluster = cluster;
     this.address = serviceReference.address();
     this.memberId = serviceReference.memberId();
-    
+
     this.tags = toMap(tags);
   }
 

--- a/services/src/main/java/io/scalecube/services/ServiceConfig.java
+++ b/services/src/main/java/io/scalecube/services/ServiceConfig.java
@@ -1,0 +1,111 @@
+package io.scalecube.services;
+
+import io.scalecube.services.ServiceConfig.Builder.ServiceContext;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+public class ServiceConfig {
+
+  private List<ServiceContext> serviceTags = new ArrayList<>();
+
+  public List<ServiceContext> getServiceTags() {
+    return serviceTags;
+  }
+
+  public void setServiceTags(List<ServiceContext> serviceTags) {
+    this.serviceTags = serviceTags;
+  }
+
+  ServiceConfig() {}
+
+  ServiceConfig(List<ServiceContext> unmodifiableList) {
+    this.serviceTags = unmodifiableList;
+  }
+
+  public List<ServiceContext> services() {
+    return this.serviceTags;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    List<ServiceContext> services = new ArrayList();
+
+    static class ServiceContext {
+
+      private final Object service;
+
+      private final Map<String, String> kv = new HashMap<String, String>();
+      private final Builder builder;
+
+      public ServiceContext(Builder builder, Object service) {
+        this.service = service;
+        this.builder = builder;
+      }
+
+      public ServiceContext(Object obj) {
+        this.service = obj;
+        this.builder = null;
+      }
+
+      public ServiceContext tag(String key, String value) {
+        kv.put(key, value);
+        return this;
+      }
+
+      public Builder add() {
+        return builder.add(this);
+      }
+
+      public Tag[] getTags() {
+
+        List<Tag> tagList = kv.entrySet().stream()
+            .map(entry -> toTag(entry))
+            .collect(Collectors.toList());
+
+        return tagList.toArray(new Tag[tagList.size()]);
+      }
+
+      private Tag toTag(Entry<String, String> entry) {
+        return new Tag(entry.getKey(), entry.getValue());
+      }
+
+      public Object getService() {
+        return this.service;
+      }
+
+    }
+
+    public ServiceContext service(Object object) {
+      return new ServiceContext(this, object);
+    }
+
+    Builder add(ServiceContext serviceBuilder) {
+      services.add(serviceBuilder);
+      return this;
+    }
+
+    public ServiceConfig build() {
+      return new ServiceConfig(Collections.unmodifiableList(services));
+    }
+
+    public Builder services(Object[] objects) {
+      for (Object o : objects) {
+        this.add(new ServiceContext(o));
+      }
+      return this;
+    }
+  }
+
+  public static ServiceConfig from(Object[] services) {
+    return ServiceConfig.builder().services(services).build();
+  }
+}

--- a/services/src/main/java/io/scalecube/services/ServiceHeaders.java
+++ b/services/src/main/java/io/scalecube/services/ServiceHeaders.java
@@ -14,8 +14,7 @@ public final class ServiceHeaders {
   public static final String METHOD = "m";
 
   /**
-   * Extract header value from a given message.
-   * the service method to invoke on request.
+   * Extract header value from a given message. the service method to invoke on request.
    */
   public static String service_method_of(Message request) {
     return request.header(METHOD);
@@ -28,8 +27,7 @@ public final class ServiceHeaders {
   public static final String SERVICE = "service";
 
   /**
-   * Extract header value from a given message.
-   * header is used to mark this registration as a microservice instance.
+   * Extract header value from a given message. header is used to mark this registration as a microservice instance.
    */
   public static String service_of(Message request) {
     return request.header(SERVICE);
@@ -42,8 +40,7 @@ public final class ServiceHeaders {
   public static final String SERVICE_REQUEST = "service-request";
 
   /**
-   * Extract header value from a given message.
-   * is used to mark a request as a service request.
+   * Extract header value from a given message. is used to mark a request as a service request.
    */
   public static String service_request_of(Message request) {
     return request.header(SERVICE_REQUEST);
@@ -56,8 +53,7 @@ public final class ServiceHeaders {
   public static final String SERVICE_RESPONSE = "service-response";
 
   /**
-   * Extract header value from a given message.
-   * header is used to mark a request as a service response.
+   * Extract header value from a given message. header is used to mark a request as a service response.
    */
   public static String service_response_of(Message request) {
     return request.header(SERVICE_RESPONSE);

--- a/services/src/main/java/io/scalecube/services/ServiceInfo.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInfo.java
@@ -1,16 +1,10 @@
 package io.scalecube.services;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
- * Helper class used to register service with tags as metadata in the scalecube cluster.
- * parsing from service info to json and back.
+ * Helper class used to register service with tags as metadata in the scalecube cluster. parsing from service info to
+ * json and back.
  */
 public class ServiceInfo {
-
-  @JsonIgnore
-  private static final ObjectMapper mapper = new ObjectMapper();
 
   private String serviceName;
 
@@ -39,41 +33,5 @@ public class ServiceInfo {
 
   private void setTags(Tag[] tags) {
     this.tags = tags;
-  }
-
-  /**
-   * Create service Advertisement from a json format.
-   * @param value json value of a registration info.
-   * @return instance of service Advertisement.
-   */
-  public static ServiceInfo from(String value) {
-    try {
-      return mapper.readValue(value, ServiceInfo.class);
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
-    }
-  }
-
-  /**
-   * Create json format of a service Advertisement.
-   * @param value instance value of a Advertisement.
-   * @return json value of a registration info.
-   */
-  public static String toJson(ServiceInfo value) {
-    try {
-      return mapper.writeValueAsString(value);
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
-    }
-  }
-
-  /**
-   * Create json format of a service Advertisement.
-   * @param serviceName given a service name.
-   * @param tags given a service tags.
-   * @return  json value of a registration info.
-   */
-  public static String toJson(String serviceName, Tag[] tags) {
-    return toJson(new ServiceInfo(serviceName, tags));
   }
 }

--- a/services/src/main/java/io/scalecube/services/ServiceInfo.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInfo.java
@@ -1,0 +1,79 @@
+package io.scalecube.services;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Helper class used to register service with tags as metadata in the scalecube cluster.
+ * parsing from service info to json and back.
+ */
+public class ServiceInfo {
+
+  @JsonIgnore
+  private static final ObjectMapper mapper = new ObjectMapper();
+
+  private String serviceName;
+
+  private Tag[] tags;
+
+  public ServiceInfo() {
+    // default contractor used for json serialization.
+  }
+
+  public ServiceInfo(String serviceName, Tag[] tags) {
+    this.serviceName = serviceName;
+    this.tags = tags;
+  }
+
+  public Tag[] getTags() {
+    return tags;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  private void setServiceName(String serviceName) {
+    this.serviceName = serviceName;
+  }
+
+  private void setTags(Tag[] tags) {
+    this.tags = tags;
+  }
+
+  /**
+   * Create service Advertisement from a json format.
+   * @param value json value of a registration info.
+   * @return instance of service Advertisement.
+   */
+  public static ServiceInfo from(String value) {
+    try {
+      return mapper.readValue(value, ServiceInfo.class);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  /**
+   * Create json format of a service Advertisement.
+   * @param value instance value of a Advertisement.
+   * @return json value of a registration info.
+   */
+  public static String toJson(ServiceInfo value) {
+    try {
+      return mapper.writeValueAsString(value);
+    } catch (Exception ex) {
+      throw new RuntimeException(ex);
+    }
+  }
+
+  /**
+   * Create json format of a service Advertisement.
+   * @param serviceName given a service name.
+   * @param tags given a service tags.
+   * @return  json value of a registration info.
+   */
+  public static String toJson(String serviceName, Tag[] tags) {
+    return toJson(new ServiceInfo(serviceName, tags));
+  }
+}

--- a/services/src/main/java/io/scalecube/services/ServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInstance.java
@@ -2,6 +2,8 @@ package io.scalecube.services;
 
 import io.scalecube.transport.Message;
 
+import java.util.Map;
+
 public interface ServiceInstance {
 
   String serviceName();
@@ -12,4 +14,5 @@ public interface ServiceInstance {
 
   Boolean isLocal();
 
+  Map<String,String> tags();
 }

--- a/services/src/main/java/io/scalecube/services/ServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInstance.java
@@ -14,5 +14,5 @@ public interface ServiceInstance {
 
   Boolean isLocal();
 
-  Map<String,String> tags();
+  Map<String, String> tags();
 }

--- a/services/src/main/java/io/scalecube/services/ServiceRegistry.java
+++ b/services/src/main/java/io/scalecube/services/ServiceRegistry.java
@@ -1,5 +1,7 @@
 package io.scalecube.services;
 
+import io.scalecube.cluster.ICluster;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -10,7 +12,7 @@ import java.util.Optional;
  */
 public interface ServiceRegistry {
 
-  void registerService(Object serviceObject);
+  void registerService(Object serviceObject, Tag[] tags);
 
   void unregisterService(Object serviceObject);
 
@@ -19,5 +21,7 @@ public interface ServiceRegistry {
   Optional<ServiceInstance> getLocalInstance(String serviceName, String method);
 
   Collection<ServiceInstance> services();
+
+  ICluster cluster();
 
 }

--- a/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
@@ -44,7 +44,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
    * @param isSeed indication if this member is seed.
    */
   public ServiceRegistryImpl(ICluster cluster, ServiceConfig serviceConfig, ServiceProcessor serviceProcessor,
-                             boolean isSeed) {
+      boolean isSeed) {
     checkArgument(cluster != null);
     checkArgument(serviceConfig.services() != null);
     checkArgument(serviceProcessor != null);
@@ -55,7 +55,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
 
     if (!serviceConfig.services().isEmpty()) {
       for (ServiceContext serviceConf : serviceConfig.services()) {
-        registerService(serviceConf.getService(),serviceConf.getTags());
+        registerService(serviceConf.getService(), serviceConf.getTags());
       }
     }
 
@@ -100,7 +100,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
         .filter(entry -> "service".equals(entry.getValue())) // filter service tags
         .forEach(entry -> {
 
-          ServiceInfo adv = ServiceInfo.from(entry.getKey());
+          ServiceInfo adv = JsonUtil.from(entry.getKey(), ServiceInfo.class);
 
           ServiceReference serviceRef = new ServiceReference(
               member.id(),
@@ -134,7 +134,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
 
       ServiceInstance serviceInstance =
           new LocalServiceInstance(serviceObject, memberId, serviceDefinitions.serviceName(),
-              serviceDefinitions.methods(),tags);
+              serviceDefinitions.methods(), tags);
       serviceInstances.putIfAbsent(serviceRef, serviceInstance);
 
     });

--- a/services/src/main/java/io/scalecube/services/Tag.java
+++ b/services/src/main/java/io/scalecube/services/Tag.java
@@ -1,0 +1,36 @@
+package io.scalecube.services;
+
+public class Tag {
+  public Tag() {
+    // default contractor for serialization
+  }
+
+  private String key;
+  private String value;
+
+  public Tag(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return "Tag [key=" + key + ", value=" + value + "]";
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  private void setValue(String value) {
+    this.value = value;
+  }
+
+  private void setKey(String key) {
+    this.key = key;
+  }
+}

--- a/services/src/main/java/io/scalecube/services/routing/RandomServiceRouter.java
+++ b/services/src/main/java/io/scalecube/services/routing/RandomServiceRouter.java
@@ -26,5 +26,4 @@ public class RandomServiceRouter implements Router {
       return Optional.empty();
     }
   }
-
 }

--- a/services/src/test/java/io/scalecube/services/GreetingRequest.java
+++ b/services/src/test/java/io/scalecube/services/GreetingRequest.java
@@ -2,7 +2,7 @@ package io.scalecube.services;
 
 import java.time.Duration;
 
-final class GreetingRequest {
+public final class GreetingRequest {
 
   private final String name;
   private final Duration duration;

--- a/services/src/test/java/io/scalecube/services/GreetingResponse.java
+++ b/services/src/test/java/io/scalecube/services/GreetingResponse.java
@@ -1,6 +1,6 @@
 package io.scalecube.services;
 
-final class GreetingResponse {
+public final class GreetingResponse {
 
   private final String result;
 

--- a/services/src/test/java/io/scalecube/services/GreetingService.java
+++ b/services/src/test/java/io/scalecube/services/GreetingService.java
@@ -7,7 +7,7 @@ import io.scalecube.transport.Message;
 import java.util.concurrent.CompletableFuture;
 
 @Service
-interface GreetingService {
+public interface GreetingService {
 
   @ServiceMethod
   CompletableFuture<String> greetingNoParams();

--- a/services/src/test/java/io/scalecube/services/ServiceTagsTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceTagsTest.java
@@ -1,0 +1,64 @@
+package io.scalecube.services;
+
+import static org.junit.Assert.assertTrue;
+
+import io.scalecube.services.ServiceConfig.Builder.ServiceContext;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class ServiceTagsTest {
+
+  @Test
+  public void create_and_validate_tags() throws IOException {
+
+    ServiceConfig config = ServiceConfig.builder()
+        .service("service1").tag("key1", "value1").tag("key2", "value2").add()
+        .service("service2").tag("key3", "value3").tag("key4", "value4").add()
+        .build();
+
+    ServiceContext service = config.services().get(0);
+
+    // TEST SERVICE 1
+    assertTrue(service.getService().equals("service1"));
+
+    // TEST SERVICE 1 KEYS
+    assertTrue(service.getTags()[0].getKey().equals("key1"));
+    assertTrue(service.getTags()[1].getKey().equals("key2"));
+
+    // TEST SERVICE 1 VALUES
+    assertTrue(service.getTags()[0].getValue().equals("value1"));
+    assertTrue(service.getTags()[1].getValue().equals("value2"));
+
+
+    // TEST SERVICE 2
+    service = config.services().get(1);
+    assertTrue(service.getService().equals("service2"));
+
+    // TEST SERVICE 2 KEYS
+    assertTrue(service.getTags()[0].getKey().equals("key3"));
+    assertTrue(service.getTags()[1].getKey().equals("key4"));
+
+    // TEST SERVICE 2 VALUES
+    assertTrue(service.getTags()[0].getValue().equals("value3"));
+    assertTrue(service.getTags()[1].getValue().equals("value4"));
+
+  }
+
+  @Test
+  public void create_and_serialize_deserialize_tags() throws JsonProcessingException {
+    ServiceConfig config = ServiceConfig.builder()
+        .service("service1").tag("key1", "value1").tag("key2", "value2").add()
+        .service("service2").tag("key3", "value3").tag("key4", "value4").add()
+        .build();
+
+    ObjectMapper mapper = new ObjectMapper();
+    String value = mapper.writeValueAsString(config.services().get(0).getTags());
+    assertTrue("[{\"key\":\"key1\",\"value\":\"value1\"},{\"key\":\"key2\",\"value\":\"value2\"}]".equals(value));
+
+  }
+}

--- a/services/src/test/java/io/scalecube/services/ServicesIT.java
+++ b/services/src/test/java/io/scalecube/services/ServicesIT.java
@@ -2,6 +2,9 @@ package io.scalecube.services;
 
 import static org.junit.Assert.*;
 
+import io.scalecube.services.a.b.testing.ABTestingRouter;
+import io.scalecube.services.a.b.testing.GreetingServiceImplA;
+import io.scalecube.services.a.b.testing.GreetingServiceImplB;
 import io.scalecube.transport.Message;
 
 import org.junit.Test;
@@ -115,6 +118,80 @@ public class ServicesIT {
   }
 
   @Test
+  public void test_illigal_state_services_and_service_config() {
+    try {
+      // Create microservices cluster.
+      Microservices.builder()
+          .port(port.incrementAndGet())
+          // configuration ServiceConfig is not allowed when using services()
+          .services(ServiceConfig.builder().service(new GreetingServiceImplA()).add()
+              .build())
+          // configuration services is not allowed when using ServiceConfig
+          .services(new GreetingServiceImplA()) 
+          .build();
+    } catch (IllegalStateException ex) {
+      assertTrue(ex != null);
+    }
+  }
+
+
+  @Test
+  public void test_remote_async_greeting_with_A_B_tags() {
+
+    // Create microservices instance.
+    Microservices gateway = Microservices.builder()
+        .port(port.incrementAndGet())
+        .build();
+
+
+    // Create microservices cluster.
+    Microservices microservices1 = Microservices.builder()
+        .port(port.incrementAndGet())
+        .seeds(gateway.cluster().address())
+        .services(ServiceConfig.builder().service(new GreetingServiceImplA())
+            .tag("A/B-Testing", "A").tag("Weight", "0.3").add()
+            .build())
+        .build();
+
+    Microservices microservices2 = Microservices.builder()
+        .port(port.incrementAndGet())
+        .seeds(gateway.cluster().address())
+        .services(ServiceConfig.builder().service(new GreetingServiceImplB())
+            .tag("A/B-Testing", "B").tag("Weight", "0.7").add().build())
+        .build();
+
+    // get a proxy to the service api.
+    GreetingService service = gateway.proxy()
+        .api(GreetingService.class) // create proxy for GreetingService API
+        .router(ABTestingRouter.class)
+        .create();
+
+    AtomicInteger count = new AtomicInteger(0);
+    // call the service.
+    for (int i = 0; i < 100; i++) {
+      CompletableFuture<String> future = service.greeting("joe");
+      CountDownLatch timeLatch = new CountDownLatch(1);
+
+      future.whenComplete((result, ex) -> {
+        if (ex == null) {
+          if (result.startsWith("B"))
+            count.incrementAndGet();
+        } else {
+          // print the greeting.
+          System.out.println(ex);
+        }
+        timeLatch.countDown();
+      });
+
+      await(timeLatch, 1, TimeUnit.SECONDS);
+    }
+    // print the greeting.
+    System.out.println("out of 100 times B was selected :" + count.get());
+    assertTrue((count.get() >= 60 && count.get() <= 80));
+    microservices1.cluster().shutdown();
+  }
+
+  @Test
   public void test_local_async_no_params() {
     // Create microservices cluster.
     Microservices microservices = Microservices.builder()
@@ -144,7 +221,7 @@ public class ServicesIT {
     await(timeLatch, 1, TimeUnit.SECONDS);
     microservices.cluster().shutdown();
   }
-  
+
   @Test
   public void test_remote_void_greeting() {
     // Create microservices instance.
@@ -169,7 +246,7 @@ public class ServicesIT {
     // but at least we didn't get exception :)
     assertTrue(true);
     System.out.println("test_remote_void_greeting done.");
-    
+
   }
 
   @Test
@@ -227,7 +304,7 @@ public class ServicesIT {
     provider.cluster().shutdown();
     consumer.cluster().shutdown();
   }
-  
+
   @Test
   public void test_remote_async_greeting_no_params() {
     // Create microservices cluster.
@@ -387,7 +464,7 @@ public class ServicesIT {
         service.greetingRequestTimeout(new GreetingRequest("joe", Duration.ofSeconds(4)));
 
     CountDownLatch timeLatch = new CountDownLatch(1);
-    
+
     result.whenComplete((success, error) -> {
       if (error != null) {
         // print the greeting.
@@ -399,7 +476,7 @@ public class ServicesIT {
 
     try {
       await(timeLatch, 10, TimeUnit.SECONDS);
-    } catch ( Exception ex){
+    } catch (Exception ex) {
       fail();
     }
   }
@@ -542,7 +619,7 @@ public class ServicesIT {
   }
 
   @Test
-  public void test_naive_stress_not_breaking_the_system() throws InterruptedException{
+  public void test_naive_stress_not_breaking_the_system() throws InterruptedException {
     // Create microservices cluster member.
     Microservices provider = Microservices.builder()
         .port(port.incrementAndGet())
@@ -592,7 +669,7 @@ public class ServicesIT {
     System.out.println("Finished receiving " + count + " messages in " + (System.currentTimeMillis() - startTime));
     assertTrue(countLatch.getCount() == 0);
   }
-  
+
   private GreetingService createProxy(Microservices gateway) {
     return gateway.proxy()
         .api(GreetingService.class) // create proxy for GreetingService API

--- a/services/src/test/java/io/scalecube/services/a/b/testing/ABTestingRouter.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/ABTestingRouter.java
@@ -1,0 +1,28 @@
+package io.scalecube.services.a.b.testing;
+
+import io.scalecube.services.ServiceDefinition;
+import io.scalecube.services.ServiceInstance;
+import io.scalecube.services.ServiceRegistry;
+import io.scalecube.services.routing.Router;
+
+import java.util.Optional;
+
+public class ABTestingRouter implements Router {
+
+  private ServiceRegistry serviceRegistry;
+
+  public ABTestingRouter(ServiceRegistry serviceRegistry) {
+    this.serviceRegistry = serviceRegistry;
+  }
+
+  @Override
+  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition) {
+    RandomCollection<ServiceInstance> weightedRandom = new RandomCollection<>();    
+    serviceRegistry.serviceLookup(serviceDefinition.serviceName()).stream().forEach(instance->{
+      weightedRandom.add(
+          Double.valueOf(instance.tags().get("Weight")), 
+          instance);
+    });
+    return Optional.of(weightedRandom.next());
+  }
+}

--- a/services/src/test/java/io/scalecube/services/a/b/testing/CanaryService.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/CanaryService.java
@@ -1,0 +1,14 @@
+package io.scalecube.services.a.b.testing;
+
+import io.scalecube.services.annotations.Service;
+import io.scalecube.services.annotations.ServiceMethod;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public interface CanaryService {
+
+  @ServiceMethod
+  CompletableFuture<String> greeting(String string);
+
+}

--- a/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
@@ -7,20 +7,20 @@ import io.scalecube.services.routing.Router;
 
 import java.util.Optional;
 
-public class ABTestingRouter implements Router {
+public class CanaryTestingRouter implements Router {
 
   private ServiceRegistry serviceRegistry;
 
-  public ABTestingRouter(ServiceRegistry serviceRegistry) {
+  public CanaryTestingRouter(ServiceRegistry serviceRegistry) {
     this.serviceRegistry = serviceRegistry;
   }
 
   @Override
   public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition) {
-    RandomCollection<ServiceInstance> weightedRandom = new RandomCollection<>();    
-    serviceRegistry.serviceLookup(serviceDefinition.serviceName()).stream().forEach(instance->{
+    RandomCollection<ServiceInstance> weightedRandom = new RandomCollection<>();
+    serviceRegistry.serviceLookup(serviceDefinition.serviceName()).stream().forEach(instance -> {
       weightedRandom.add(
-          Double.valueOf(instance.tags().get("Weight")), 
+          Double.valueOf(instance.tags().get("Weight")),
           instance);
     });
     return Optional.of(weightedRandom.next());

--- a/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplA.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplA.java
@@ -1,44 +1,11 @@
 package io.scalecube.services.a.b.testing;
 
-import io.scalecube.services.GreetingRequest;
-import io.scalecube.services.GreetingResponse;
-import io.scalecube.services.GreetingService;
-import io.scalecube.transport.Message;
-
 import java.util.concurrent.CompletableFuture;
 
-public final class GreetingServiceImplA implements GreetingService {
+public final class GreetingServiceImplA implements CanaryService {
 
   @Override
   public CompletableFuture<String> greeting(String name) {
     return CompletableFuture.completedFuture("A - hello to: " + name);
-  }
-
-  @Override
-  public CompletableFuture<String> greetingNoParams() {
-    return CompletableFuture.completedFuture("hello unknown");
-  }
-
-  @Override
-  public CompletableFuture<Message> greetingMessage(Message request) {
-    return CompletableFuture.completedFuture(Message.fromData(" hello to: " + request.data()));
-  }
-
-  @Override
-  public CompletableFuture<GreetingResponse> greetingRequestTimeout(GreetingRequest request) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public CompletableFuture<GreetingResponse> greetingRequest(GreetingRequest string) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public void greetingVoid(GreetingRequest request) {
-    // TODO Auto-generated method stub
-
   }
 }

--- a/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplA.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplA.java
@@ -1,0 +1,44 @@
+package io.scalecube.services.a.b.testing;
+
+import io.scalecube.services.GreetingRequest;
+import io.scalecube.services.GreetingResponse;
+import io.scalecube.services.GreetingService;
+import io.scalecube.transport.Message;
+
+import java.util.concurrent.CompletableFuture;
+
+public final class GreetingServiceImplA implements GreetingService {
+
+  @Override
+  public CompletableFuture<String> greeting(String name) {
+    return CompletableFuture.completedFuture("A - hello to: " + name);
+  }
+
+  @Override
+  public CompletableFuture<String> greetingNoParams() {
+    return CompletableFuture.completedFuture("hello unknown");
+  }
+
+  @Override
+  public CompletableFuture<Message> greetingMessage(Message request) {
+    return CompletableFuture.completedFuture(Message.fromData(" hello to: " + request.data()));
+  }
+
+  @Override
+  public CompletableFuture<GreetingResponse> greetingRequestTimeout(GreetingRequest request) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<GreetingResponse> greetingRequest(GreetingRequest string) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void greetingVoid(GreetingRequest request) {
+    // TODO Auto-generated method stub
+
+  }
+}

--- a/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplB.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplB.java
@@ -1,0 +1,45 @@
+package io.scalecube.services.a.b.testing;
+
+import io.scalecube.services.GreetingRequest;
+import io.scalecube.services.GreetingResponse;
+import io.scalecube.services.GreetingService;
+import io.scalecube.transport.Message;
+
+import java.util.concurrent.CompletableFuture;
+
+public final class GreetingServiceImplB implements GreetingService {
+
+  @Override
+  public CompletableFuture<String> greeting(String name) {
+    return CompletableFuture.completedFuture("B - hello to: " + name);
+  }
+
+  @Override
+  public CompletableFuture<String> greetingNoParams() {
+    return CompletableFuture.completedFuture("hello unknown");
+  }
+
+  @Override
+  public CompletableFuture<Message> greetingMessage(Message request) {
+    return CompletableFuture.completedFuture(Message.fromData(" hello to: " + request.data()));
+  }
+
+  @Override
+  public CompletableFuture<GreetingResponse> greetingRequestTimeout(GreetingRequest request) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<GreetingResponse> greetingRequest(GreetingRequest string) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public void greetingVoid(GreetingRequest request) {
+    // TODO Auto-generated method stub
+
+  }
+
+}

--- a/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplB.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/GreetingServiceImplB.java
@@ -1,45 +1,11 @@
 package io.scalecube.services.a.b.testing;
 
-import io.scalecube.services.GreetingRequest;
-import io.scalecube.services.GreetingResponse;
-import io.scalecube.services.GreetingService;
-import io.scalecube.transport.Message;
-
 import java.util.concurrent.CompletableFuture;
 
-public final class GreetingServiceImplB implements GreetingService {
+public final class GreetingServiceImplB implements CanaryService {
 
   @Override
   public CompletableFuture<String> greeting(String name) {
     return CompletableFuture.completedFuture("B - hello to: " + name);
   }
-
-  @Override
-  public CompletableFuture<String> greetingNoParams() {
-    return CompletableFuture.completedFuture("hello unknown");
-  }
-
-  @Override
-  public CompletableFuture<Message> greetingMessage(Message request) {
-    return CompletableFuture.completedFuture(Message.fromData(" hello to: " + request.data()));
-  }
-
-  @Override
-  public CompletableFuture<GreetingResponse> greetingRequestTimeout(GreetingRequest request) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public CompletableFuture<GreetingResponse> greetingRequest(GreetingRequest string) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-  @Override
-  public void greetingVoid(GreetingRequest request) {
-    // TODO Auto-generated method stub
-
-  }
-
 }

--- a/services/src/test/java/io/scalecube/services/a/b/testing/RandomCollection.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/RandomCollection.java
@@ -1,0 +1,21 @@
+package io.scalecube.services.a.b.testing;
+
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class RandomCollection<E> {
+  private final NavigableMap<Double, E> map = new TreeMap<Double, E>();
+  private double total = 0;
+  
+  public void add(double weight, E result) {
+    if (weight > 0 && !map.containsValue(result)) {
+      map.put(total += weight, result);
+    }
+  }
+
+  public E next() {
+    double value = ThreadLocalRandom.current().nextDouble() * total;
+    return map.ceilingEntry(value).getValue();
+  }
+}

--- a/services/src/test/java/io/scalecube/services/a/b/testing/RandomCollection.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/RandomCollection.java
@@ -7,7 +7,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public class RandomCollection<E> {
   private final NavigableMap<Double, E> map = new TreeMap<Double, E>();
   private double total = 0;
-  
+
   public void add(double weight, E result) {
     if (weight > 0 && !map.containsValue(result)) {
       map.put(total += weight, result);


### PR DESCRIPTION
when building the cluster so each service can now accept
key/value tags also the example test demo how you can implement a
weighted random service selection for A/B testing of services so when
there are different algo running and gracefully allocating resources to
specific service instance while testing its business performance in the
cluster.
read more about: http://techblog.netflix.com/2013/08/deploying-netflix-api.html