### PR TITLE
Support service dispatchers

### DIFF
--- a/services/src/main/java/io/scalecube/services/DispatchingFuture.java
+++ b/services/src/main/java/io/scalecube/services/DispatchingFuture.java
@@ -33,6 +33,7 @@ public class DispatchingFuture {
 
   /**
    * private contractor use static method from.
+   * 
    * @param cluster instance.
    * @param request original service request.
    */
@@ -53,6 +54,8 @@ public class DispatchingFuture {
       completeExceptionally(Throwable.class.cast(value));
     } else if (value instanceof CompletableFuture<?>) {
       handleComputable(cluster, CompletableFuture.class.cast(value));
+    } else if (value == null) {
+      handleComputable(cluster, CompletableFuture.completedFuture(null));
     }
   }
 

--- a/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
@@ -45,7 +45,7 @@ public class LocalServiceInstance implements ServiceInstance {
 
 
   @Override
-  public Object invoke(Message message, ServiceDefinition definition) throws Exception {
+  public Object invoke(Message message) throws Exception {
     checkArgument(message != null);
 
     try {

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -31,12 +31,14 @@ import java.util.Optional;
  * compose. True isolation is achieved through shared-nothing design. This means the services in ScaleCube are
  * autonomous, loosely coupled and mobile (location transparent)—necessary requirements for resilence and elasticity
  * 
- * <p>ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
+ * <p>
+ * ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
  * build the service component itself. the Service component is simply java class that implements the service Interface
  * and ScaleCube take care for the rest of the magic. it derived and influenced by Actor model and reactive and
  * streaming patters but does not force application developers to it.
  * 
- * <p>ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
+ * <p>
+ * ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
  * <li>location transparency and discovery of service instances.</li>
  * <li>fault tolerance using gossip and failure detection.</li>
  * <li>share nothing - fully distributed and decentralized architecture.</li>
@@ -47,7 +49,8 @@ import java.util.Optional;
  * <li>low latency</li>
  * <li>supports routing extensible strategies when selecting service endpoints</li>
  * 
- * </p><b>basic usage example:</b>
+ * </p>
+ * <b>basic usage example:</b>
  * 
  * <pre>
  * 
@@ -111,9 +114,10 @@ public class Microservices {
   private Microservices(ICluster cluster, ServicesConfig services, boolean isSeed) {
     this.cluster = cluster;
     this.serviceRegistry = new ServiceRegistryImpl(cluster, services, serviceProcessor, isSeed);
+    
+    this.proxyFactory = new ServiceProxyFactory(serviceRegistry);
     this.dispatcherFactory = new ServiceDispatcherFactory(serviceRegistry);
 
-    this.proxyFactory = new ServiceProxyFactory(serviceRegistry, serviceProcessor);
     new ServiceDispatcher(cluster, serviceRegistry);
     this.cluster.listen().subscribe(message -> handleReply(message));
   }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -31,30 +31,27 @@ import java.util.Optional;
  * compose. True isolation is achieved through shared-nothing design. This means the services in ScaleCube are
  * autonomous, loosely coupled and mobile (location transparent)—necessary requirements for resilence and elasticity
  * 
- * <p>
- * ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
+ * <p>ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
  * build the service component itself. the Service component is simply java class that implements the service Interface
  * and ScaleCube take care for the rest of the magic. it derived and influenced by Actor model and reactive and
  * streaming patters but does not force application developers to it.
  * 
- * <p>
- * ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
+ * <p>ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
  * <li>location transparency and discovery of service instances.</li>
  * <li>fault tolerance using gossip and failure detection.</li>
  * <li>share nothing - fully distributed and decentralized architecture.</li>
  * <li>Provides fluent, java 8 lambda apis.</li>
- * <li>embeddable and lightweight.</li>
+ * <li>Embeddable and lightweight.</li>
  * <li>utilizes completable futures but primitives and messages can be used as well completable futures gives the
  * advantage of composing and chaining service calls and service results.</li>
  * <li>low latency</li>
- * <li>supports routing extensible strategies when selecting service endpoints</li>
+ * <li>supports routing extensible strategies when selecting service end-points</li>
  * 
- * </p>
- * <b>basic usage example:</b>
+ * </p><b>basic usage example:</b>
  * 
  * <pre>
  * 
- * <b><font color="green">//Define a serivce interface and implement it.</font></b>
+ * <b><font color="green">//Define a service interface and implement it.</font></b>
  * {@code
  *    <b>{@literal @}Service</b>
  *    <b><font color="9b0d9b">public interface</font></b> GreetingService {  

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -123,7 +123,7 @@ public class Microservices {
   private void handleReply(Message message) {
     if (message.header(ServiceHeaders.SERVICE_RESPONSE) != null) {
       String correlationId = message.correlationId();
-      Optional<ResponseFuture> optinalFuture = ResponseFuture.get(message.correlationId());
+      Optional<ServiceResponse> optinalFuture = ServiceResponse.get(message.correlationId());
       if (optinalFuture.isPresent()) {
         if (message.header("exception") == null) {
           optinalFuture.get().complete(message);

--- a/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
@@ -56,7 +56,7 @@ public class RemoteServiceInstance implements ServiceInstance {
    * @throws Exception in case of an error
    */
   public CompletableFuture<Object> dispatch(Message request) throws Exception {
-    ResponseFuture responseFuture = new ResponseFuture(fn -> request);
+    ServiceResponse responseFuture = new ServiceResponse(fn -> request);
     Message requestMessage = composeRequest(request, responseFuture.correlationId());
 
     // Resolve method
@@ -105,7 +105,7 @@ public class RemoteServiceInstance implements ServiceInstance {
 
   private CompletableFuture<Object> futureInvoke(final Message request, Function<Message, Object> fn) throws Exception {
 
-    ResponseFuture responseFuture = new ResponseFuture(fn);
+    ServiceResponse responseFuture = new ServiceResponse(fn);
 
     Message requestMessage = composeRequest(request, responseFuture.correlationId());
 
@@ -118,7 +118,7 @@ public class RemoteServiceInstance implements ServiceInstance {
             requestMessage, error);
 
         // if send future faild then complete the response future Exceptionally.
-        Optional<ResponseFuture> future = ResponseFuture.get(requestMessage.correlationId());
+        Optional<ServiceResponse> future = ServiceResponse.get(requestMessage.correlationId());
         if (future.isPresent()) {
           future.get().completeExceptionally(error);
         }

--- a/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
@@ -32,10 +32,12 @@ public class RemoteServiceInstance implements ServiceInstance {
   /**
    * Remote service instance constructor to initiate instance.
    * 
-   * @param cluster to be used for instance context.
+   * @param serviceRegistry to be used for instance context.
    * @param serviceReference service reference of this instance.
+   * @param tags describing this service instance metadata.
    */
-  public RemoteServiceInstance(ServiceRegistry serviceRegistry, ServiceReference serviceReference, Map<String, String> tags) {
+  public RemoteServiceInstance(ServiceRegistry serviceRegistry, ServiceReference serviceReference,
+      Map<String, String> tags) {
     this.serviceRegistry = serviceRegistry;
     this.serviceName = serviceReference.serviceName();
     this.cluster = serviceRegistry.cluster();

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -1,0 +1,153 @@
+package io.scalecube.services;
+
+import io.scalecube.services.routing.Router;
+import io.scalecube.transport.Message;
+import io.scalecube.transport.Message.Builder;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+public class ServiceCall {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceProxyFactory.class);
+
+  /**
+   * used to complete the request future with timeout exception in case no response comes from service.
+   */
+  private static final ScheduledExecutorService delayer = Executors.newSingleThreadScheduledExecutor(
+      new ThreadFactoryBuilder().setNameFormat("sc-services-timeout").setDaemon(true).build());
+
+  private Duration timeout;
+  private Router router;
+
+  public ServiceCall(Router router, Duration timeout) {
+    this.router = router;
+    this.timeout = timeout;
+  }
+
+  public <T> CompletableFuture<Message> invoke(Message message) {
+    return invoke(message, timeout);
+  }
+
+  /**
+   * Dispatch a request message and invoke a service by a given service name and method name. expected headers in
+   * request: ServiceHeaders.SERVICE_REQUEST the logical name of the service. ServiceHeaders.METHOD the method name to
+   * invoke.
+   * 
+   * @param request request with given headers.
+   * @timeout duration of the response before TimeException is returned.
+   * @return CompletableFuture with service call dispatching result.
+   * @throws Exception in case of an error or TimeoutException if no response if a given duration.
+   */
+  @SuppressWarnings("unchecked")
+  public <T> CompletableFuture<Message> invoke(Message request, Duration timeout) {
+    String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
+    String methodName = request.header(ServiceHeaders.METHOD);
+    try {
+      ServiceDefinition serviceDefinition = ServiceDefinition.from(serviceName);
+      Optional<ServiceInstance> optionalServiceInstance = router.route(serviceDefinition);
+
+      if (optionalServiceInstance.isPresent()) {
+        ServiceInstance serviceInstance = optionalServiceInstance.get();
+
+        if (serviceInstance.isLocal()) {
+
+          CompletableFuture<?> resultFuture = (CompletableFuture<?>) serviceInstance.invoke(request, serviceDefinition);
+
+          return (CompletableFuture<Message>) timeoutAfter(resultFuture, timeout)
+              .thenApply(result -> toMessage(request, (T) result));
+        } else {
+
+          RemoteServiceInstance remote = (RemoteServiceInstance) serviceInstance;
+          CompletableFuture<?> resultFuture =
+              (CompletableFuture<?>) remote.dispatch(request);
+
+          return (CompletableFuture<Message>) timeoutAfter(resultFuture, timeout);
+
+        }
+      } else {
+        LOGGER.error(
+            "Failed  to invoke service, No reachable member with such service definition [{}], args [{}]",
+            serviceDefinition, request);
+        throw new IllegalStateException("No reachable member with such service: " + methodName);
+      }
+
+    } catch (Throwable ex) {
+      LOGGER.error(
+          "Failed  to invoke service, No reachable member with such service method [{}], args [{}], error [{}]",
+          methodName, request.data(), ex);
+      throw new IllegalStateException("No reachable member with such service: " + methodName);
+    }
+  }
+
+  private <T> Message toMessage(Message request, T result) {
+    if (result instanceof Message) {
+      return (Message) result;
+    } else {
+      return Message.builder()
+          .header(ServiceHeaders.SERVICE_RESPONSE, request.header(ServiceHeaders.SERVICE_REQUEST))
+          .header(ServiceHeaders.METHOD, request.header(ServiceHeaders.METHOD))
+          .correlationId(request.correlationId())
+          .qualifier(request.qualifier())
+          .data(result)
+          .build();
+    }
+  }
+
+  private CompletableFuture<?> timeoutAfter(final CompletableFuture<?> resultFuture, Duration timeout) {
+
+    final CompletableFuture<Class<Void>> timeoutFuture = new CompletableFuture<>();
+
+    // schedule to terminate the target goal in future in case it was not done yet
+    final ScheduledFuture<?> scheduledEvent = delayer.schedule(() -> {
+      // by this time the target goal should have finished.
+      if (!resultFuture.isDone()) {
+        // target goal not finished in time so cancel it with timeout.
+        resultFuture.completeExceptionally(new TimeoutException("expecting response reached timeout!"));
+      }
+    }, timeout.toMillis(), TimeUnit.MILLISECONDS);
+
+    // cancel the timeout in case target goal did finish on time
+    if (resultFuture != null) {
+      resultFuture.thenRun(() -> {
+        if (resultFuture.isDone()) {
+          if (!scheduledEvent.isDone()) {
+            scheduledEvent.cancel(false);
+          }
+          timeoutFuture.complete(Void.TYPE);
+        }
+      });
+    } else {
+      return CompletableFuture.completedFuture(null);
+    }
+    return resultFuture;
+  }
+
+  /**
+   * helper method to get service request builder with needed headers.
+   * 
+   * @param serviceName the requested service name.
+   * @param methodName the requested service method name.
+   * @return Builder for requested message.
+   */
+  public static Builder request(String serviceName, String methodName) {
+    return Message.builder()
+        .header(ServiceHeaders.SERVICE_REQUEST, serviceName)
+        .header(ServiceHeaders.METHOD, methodName);
+
+  }
+}
+
+

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -1,10 +1,9 @@
 package io.scalecube.services;
 
 import io.scalecube.services.routing.Router;
+import io.scalecube.transport.Address;
 import io.scalecube.transport.Message;
 import io.scalecube.transport.Message.Builder;
-
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,12 +11,10 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
 
 public class ServiceCall {
 
@@ -57,7 +54,7 @@ public class ServiceCall {
     String methodName = request.header(ServiceHeaders.METHOD);
     try {
       ServiceDefinition serviceDefinition = ServiceDefinition.from(serviceName);
-      Optional<ServiceInstance> optionalServiceInstance = router.route(serviceDefinition);
+      Optional<ServiceInstance> optionalServiceInstance = router.route(serviceDefinition, request);
 
       if (optionalServiceInstance.isPresent()) {
         ServiceInstance serviceInstance = optionalServiceInstance.get();
@@ -148,6 +145,8 @@ public class ServiceCall {
         .header(ServiceHeaders.METHOD, methodName);
 
   }
+
+
 }
 
 

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -53,15 +53,15 @@ public class ServiceCall {
     String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
     String methodName = request.header(ServiceHeaders.METHOD);
     try {
-      ServiceDefinition serviceDefinition = ServiceDefinition.from(serviceName);
-      Optional<ServiceInstance> optionalServiceInstance = router.route(serviceDefinition, request);
+      
+      Optional<ServiceInstance> optionalServiceInstance = router.route(request);
 
       if (optionalServiceInstance.isPresent()) {
         ServiceInstance serviceInstance = optionalServiceInstance.get();
 
         if (serviceInstance.isLocal()) {
 
-          CompletableFuture<?> resultFuture = (CompletableFuture<?>) serviceInstance.invoke(request, serviceDefinition);
+          CompletableFuture<?> resultFuture = (CompletableFuture<?>) serviceInstance.invoke(request);
 
           return (CompletableFuture<Message>) timeoutAfter(resultFuture, timeout)
               .thenApply(result -> toMessage(request, (T) result));
@@ -77,7 +77,7 @@ public class ServiceCall {
       } else {
         LOGGER.error(
             "Failed  to invoke service, No reachable member with such service definition [{}], args [{}]",
-            serviceDefinition, request);
+            serviceName, request);
         throw new IllegalStateException("No reachable member with such service: " + methodName);
       }
 

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -26,8 +26,8 @@ public class ServiceCall {
   /**
    * used to complete the request future with timeout exception in case no response comes from service.
    */
-  private static final ScheduledExecutorService delayer = Executors.newSingleThreadScheduledExecutor(
-      new ThreadFactoryBuilder().setNameFormat("sc-services-timeout").setDaemon(true).build());
+  private static final ScheduledExecutorService delayer =
+      ThreadFactory.singleScheduledExecutorService("sc-services-timeout");
 
   private Duration timeout;
   private Router router;

--- a/services/src/main/java/io/scalecube/services/ServiceDefinition.java
+++ b/services/src/main/java/io/scalecube/services/ServiceDefinition.java
@@ -23,9 +23,14 @@ public class ServiceDefinition {
   public ServiceDefinition(Class<?> serviceInterface, String serviceName, Map<String, Method> methods) {
     this.serviceInterface = serviceInterface;
     this.serviceName = serviceName;
-    this.methods = Collections.unmodifiableMap(methods);
+    this.methods = (methods != null) ?  Collections.unmodifiableMap(methods) : null;
+
   }
 
+  public static ServiceDefinition from(String serviceName) {
+    return new ServiceDefinition(null,serviceName,null);
+  }
+  
   public Class<?> serviceInterface() {
     return serviceInterface;
   }
@@ -49,5 +54,7 @@ public class ServiceDefinition {
         + ", methods=" + methods
         + "]";
   }
+
+  
 
 }

--- a/services/src/main/java/io/scalecube/services/ServiceDispatcher.java
+++ b/services/src/main/java/io/scalecube/services/ServiceDispatcher.java
@@ -37,7 +37,7 @@ public class ServiceDispatcher {
     DispatchingFuture result = DispatchingFuture.from(cluster, request);
     try {
       if (serviceInstance.isPresent()) {
-        result.complete(serviceInstance.get().invoke(request, null));
+        result.complete(serviceInstance.get().invoke(request));
       } else {
         result.completeExceptionally(new IllegalStateException("Service instance is missing: " + request.qualifier()));
       }

--- a/services/src/main/java/io/scalecube/services/ServiceDispatcherFactory.java
+++ b/services/src/main/java/io/scalecube/services/ServiceDispatcherFactory.java
@@ -1,0 +1,20 @@
+package io.scalecube.services;
+
+import io.scalecube.services.routing.Router;
+import io.scalecube.services.routing.RouterFactory;
+
+import java.time.Duration;
+
+public class ServiceDispatcherFactory {
+
+  private final RouterFactory routerFactory;
+
+  public ServiceDispatcherFactory(ServiceRegistry serviceRegistry) {
+    this.routerFactory = new RouterFactory(serviceRegistry);
+  }
+
+  public ServiceCall createDispatcher(Class<? extends Router> routerType, Duration timeout) {
+    return new ServiceCall(routerFactory.getRouter(routerType), timeout);
+  }
+
+}

--- a/services/src/main/java/io/scalecube/services/ServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInstance.java
@@ -8,7 +8,7 @@ public interface ServiceInstance {
 
   String serviceName();
 
-  Object invoke(Message request, ServiceDefinition definition) throws Exception;
+  Object invoke(Message request) throws Exception;
 
   String memberId();
 

--- a/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
+++ b/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
@@ -58,11 +58,12 @@ public class ServiceProxyFactory {
           // fetch the service definition by the method name
           Router router = routerFactory.getRouter(routerType);
 
-          Optional<ServiceInstance> optionalServiceInstance = router.route(serviceDefinition);
+          Object data = method.getParameterCount() != 0 ? args[0] : null;
+          Optional<ServiceInstance> optionalServiceInstance = router.route(serviceDefinition, data);
 
           if (optionalServiceInstance.isPresent()) {
             ServiceInstance serviceInstance = optionalServiceInstance.get();
-            Object data = method.getParameterCount() != 0 ? args[0] : null;
+
             Message reqMsg = Message.withData(data)
                 .header(ServiceHeaders.SERVICE_REQUEST, serviceInstance.serviceName())
                 .header(ServiceHeaders.METHOD, method.getName())

--- a/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
+++ b/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
@@ -6,7 +6,6 @@ import io.scalecube.services.routing.RouterFactory;
 import io.scalecube.transport.Message;
 
 import com.google.common.reflect.Reflection;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +15,6 @@ import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -28,8 +26,8 @@ public class ServiceProxyFactory {
   /**
    * used to complete the request future with timeout exception in case no response comes from service.
    */
-  private static final ScheduledExecutorService delayer = Executors.newSingleThreadScheduledExecutor(
-      new ThreadFactoryBuilder().setNameFormat("sc-services-timeout").setDaemon(true).build());
+  private static final ScheduledExecutorService delayer =
+      ThreadFactory.singleScheduledExecutorService("sc-services-timeout");
 
   private final ServiceProcessor serviceProcessor;
   ServiceDefinition serviceDefinition;

--- a/services/src/main/java/io/scalecube/services/ServiceRegistry.java
+++ b/services/src/main/java/io/scalecube/services/ServiceRegistry.java
@@ -1,5 +1,6 @@
 package io.scalecube.services;
 
+import io.scalecube.cluster.ICluster;
 import io.scalecube.services.ServicesConfig.Builder.ServiceConfig;
 
 import java.util.Collection;
@@ -21,5 +22,11 @@ public interface ServiceRegistry {
   Optional<ServiceInstance> getLocalInstance(String serviceName, String method);
 
   Collection<ServiceInstance> services();
+
+  Optional<ServiceDefinition> getServiceDefinition(String serviceName);
+
+  ServiceDefinition registerInterface(Class<?> serviceInterface);
+  
+  ICluster cluster();
 
 }

--- a/services/src/main/java/io/scalecube/services/ServiceResponse.java
+++ b/services/src/main/java/io/scalecube/services/ServiceResponse.java
@@ -14,21 +14,21 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
 /**
- * ResponseFuture handles the response of a service request based on correlationId. it holds a mapping between
+ * ServiceResponse handles the response of a service request based on correlationId. it holds a mapping between
  * correlationId to CompleteableFuture so when a response message is returned from service endpoint the future is
  * completed with success or error.
  */
-public class ResponseFuture {
+public class ServiceResponse {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ResponseFuture.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceResponse.class);
 
-  private static final ConcurrentMap<String, ResponseFuture> futures = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<String, ServiceResponse> futures = new ConcurrentHashMap<>();
 
   private final String correlationId;
   private final Function<Message, Object> function;
   private final CompletableFuture<Object> messageFuture;
 
-  public ResponseFuture(Function<Message, Object> fn) {
+  public ServiceResponse(Function<Message, Object> fn) {
     this.correlationId = generateId();
     this.function = fn;
     this.messageFuture = new CompletableFuture<>();
@@ -41,7 +41,7 @@ public class ResponseFuture {
    * @param correlationId or the request.
    * @return ResponseFuture pending completion.
    */
-  public static Optional<ResponseFuture> get(String correlationId) {
+  public static Optional<ServiceResponse> get(String correlationId) {
     return Optional.of(futures.get(correlationId));
   }
 

--- a/services/src/main/java/io/scalecube/services/ThreadFactory.java
+++ b/services/src/main/java/io/scalecube/services/ThreadFactory.java
@@ -1,0 +1,31 @@
+package io.scalecube.services;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Used to create and cache shared thread pools with given name.
+ */
+public class ThreadFactory {
+
+  static final ConcurrentMap<String, ScheduledExecutorService> schedulers = new ConcurrentHashMap<>();
+
+  /**
+   * Used to create and cache shared thread pools with given name.
+   * 
+   * @name the requested name of the single thread executor if not cached will be created.
+   */
+  public static ScheduledExecutorService singleScheduledExecutorService(String name) {
+    return schedulers.computeIfAbsent(name, func -> compute(name));
+  }
+
+  private static ScheduledExecutorService compute(String name) {
+    return Executors.newSingleThreadScheduledExecutor(
+        new ThreadFactoryBuilder().setNameFormat(name).setDaemon(true).build());
+  }
+
+}

--- a/services/src/main/java/io/scalecube/services/routing/RandomServiceRouter.java
+++ b/services/src/main/java/io/scalecube/services/routing/RandomServiceRouter.java
@@ -1,8 +1,8 @@
 package io.scalecube.services.routing;
 
-import io.scalecube.services.ServiceRegistry;
 import io.scalecube.services.ServiceDefinition;
 import io.scalecube.services.ServiceInstance;
+import io.scalecube.services.ServiceRegistry;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,7 +17,7 @@ public class RandomServiceRouter implements Router {
   }
 
   @Override
-  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition) {
+  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition, Object data) {
     List<ServiceInstance> serviceInstances = serviceRegistry.serviceLookup(serviceDefinition.serviceName());
     if (!serviceInstances.isEmpty()) {
       int index = ThreadLocalRandom.current().nextInt((serviceInstances.size()));

--- a/services/src/main/java/io/scalecube/services/routing/RandomServiceRouter.java
+++ b/services/src/main/java/io/scalecube/services/routing/RandomServiceRouter.java
@@ -1,8 +1,9 @@
 package io.scalecube.services.routing;
 
-import io.scalecube.services.ServiceDefinition;
+import io.scalecube.services.ServiceHeaders;
 import io.scalecube.services.ServiceInstance;
 import io.scalecube.services.ServiceRegistry;
+import io.scalecube.transport.Message;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,8 +18,9 @@ public class RandomServiceRouter implements Router {
   }
 
   @Override
-  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition, Object data) {
-    List<ServiceInstance> serviceInstances = serviceRegistry.serviceLookup(serviceDefinition.serviceName());
+  public Optional<ServiceInstance> route(Message request) {
+    String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
+    List<ServiceInstance> serviceInstances = serviceRegistry.serviceLookup(serviceName);
     if (!serviceInstances.isEmpty()) {
       int index = ThreadLocalRandom.current().nextInt((serviceInstances.size()));
       return Optional.of(serviceInstances.get(index));

--- a/services/src/main/java/io/scalecube/services/routing/RoundRobinServiceRouter.java
+++ b/services/src/main/java/io/scalecube/services/routing/RoundRobinServiceRouter.java
@@ -1,8 +1,8 @@
 package io.scalecube.services.routing;
 
-import io.scalecube.services.ServiceRegistry;
 import io.scalecube.services.ServiceDefinition;
 import io.scalecube.services.ServiceInstance;
+import io.scalecube.services.ServiceRegistry;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +25,7 @@ public class RoundRobinServiceRouter implements Router {
   }
 
   @Override
-  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition) {
+  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition, Object data) {
     List<ServiceInstance> serviceInstances = serviceRegistry.serviceLookup(serviceDefinition.serviceName());
     if (!serviceInstances.isEmpty()) {
       AtomicInteger counter = counterByServiceName

--- a/services/src/main/java/io/scalecube/services/routing/Router.java
+++ b/services/src/main/java/io/scalecube/services/routing/Router.java
@@ -1,12 +1,12 @@
 package io.scalecube.services.routing;
 
-import io.scalecube.services.ServiceDefinition;
 import io.scalecube.services.ServiceInstance;
+import io.scalecube.transport.Message;
 
 import java.util.Optional;
 
 public interface Router {
 
-  Optional<ServiceInstance> route(ServiceDefinition serviceDefinition, Object data);
+  Optional<ServiceInstance> route(Message request);
 
 }

--- a/services/src/main/java/io/scalecube/services/routing/Router.java
+++ b/services/src/main/java/io/scalecube/services/routing/Router.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface Router {
 
-  Optional<ServiceInstance> route(ServiceDefinition serviceDefinition);
+  Optional<ServiceInstance> route(ServiceDefinition serviceDefinition, Object data);
 
 }

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -590,6 +590,8 @@ public class ServiceCallTest extends BaseTest {
         .build()
         .build();
 
+    System.out.println( gateway.cluster().members());
+    
     ServiceCall service = gateway.dispatcher()
         .router(CanaryTestingRouter.class)
         .create();
@@ -616,8 +618,10 @@ public class ServiceCallTest extends BaseTest {
       });
     }
 
-    await(timeLatch, 1, TimeUnit.SECONDS);
+    
+    await(timeLatch, 3, TimeUnit.SECONDS);
     assertTrue((responses.get() == 100) && (60 < count.get() && count.get() < 80));
+    System.out.println("Service B was called: " + count.get()  + " times.");
   }
 
   @Test

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -229,7 +229,7 @@ public class ServiceCallTest extends BaseTest {
       }
       timeLatch.countDown();
     });
-    await(timeLatch, 1, TimeUnit.SECONDS);
+    await(timeLatch, 3, TimeUnit.SECONDS);
     microservices.cluster().shutdown();
   }
 

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -1,8 +1,8 @@
 package io.scalecube.services;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import io.scalecube.services.a.b.testing.CanaryService;
 import io.scalecube.services.a.b.testing.CanaryTestingRouter;
 import io.scalecube.services.a.b.testing.GreetingServiceImplA;
 import io.scalecube.services.a.b.testing.GreetingServiceImplB;
@@ -18,106 +18,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class ServiceTest extends BaseTest {
+public class ServiceCallTest extends BaseTest {
 
+  private static final String CANARY_SERVICE = "io.scalecube.services.a.b.testing.CanaryService";
+  public static final String SERVICE_NAME = "io.scalecube.services.GreetingService";
   private static AtomicInteger port = new AtomicInteger(4000);
-
-  @Test
-  public void test_remote_greeting_request_completes_before_timeout() {
-    Duration duration = Duration.ofSeconds(1);
-
-    // Create microservices instance.
-    Microservices gateway = Microservices.builder()
-        .port(port.incrementAndGet())
-        .build();
-
-    Microservices.builder()
-        .seeds(gateway.cluster().address())
-        .services(new GreetingServiceImpl())
-        .build();
-
-    GreetingService service = gateway.proxy()
-        .api(GreetingService.class)
-        .timeout(Duration.ofSeconds(3))
-        .create();
-
-    // call the service.
-    CompletableFuture<GreetingResponse> result = service.greetingRequestTimeout(new GreetingRequest("joe", duration));
-
-    CountDownLatch timeLatch = new CountDownLatch(1);
-    result.whenComplete((success, error) -> {
-      if (error == null) {
-        // print the greeting.
-        System.out.println("1. greeting_request_completes_before_timeout : " + success.getResult());
-        assertTrue(success.getResult().equals(" hello to: joe"));
-        timeLatch.countDown();
-      } else {
-        System.out.println("1. FAILED! - greeting_request_completes_before_timeout reached timeout: " + error);
-        assertTrue(error.toString(), false);
-        timeLatch.countDown();
-      }
-    });
-    await(timeLatch, 10, TimeUnit.SECONDS);
-  }
-
-  @Test
-  public void test_greeting_request_completes_before_timeout() {
-    Duration duration = Duration.ofSeconds(1);
-
-    // Create microservices instance.
-    GreetingService service = Microservices.builder()
-        .port(port.incrementAndGet())
-        .services(new GreetingServiceImpl())
-        .build()
-        .proxy().api(GreetingService.class)
-        .create();
-
-    // call the service.
-    CompletableFuture<GreetingResponse> result = service.greetingRequestTimeout(new GreetingRequest("joe", duration));
-
-    CountDownLatch timeLatch = new CountDownLatch(1);
-    result.whenComplete((success, error) -> {
-      if (error == null) {
-        // print the greeting.
-        System.out.println("2. greeting_request_completes_before_timeout : " + success.getResult());
-        assertTrue(success.getResult().equals(" hello to: joe"));
-        timeLatch.countDown();
-      }
-    });
-
-    await(timeLatch, 60, TimeUnit.SECONDS);
-  }
-
-  @Test
-  public void test_local_async_greeting() {
-    // Create microservices cluster.
-    Microservices microservices = Microservices.builder()
-        .port(port.incrementAndGet())
-        .services(new GreetingServiceImpl())
-        .build();
-
-    // get a proxy to the service api.
-    GreetingService service = createProxy(microservices);
-
-    // call the service.
-    CompletableFuture<String> future = service.greeting("joe");
-
-    CountDownLatch timeLatch = new CountDownLatch(1);
-    future.whenComplete((result, ex) -> {
-      if (ex == null) {
-        assertTrue(result.equals(" hello to: joe"));
-        // print the greeting.
-        System.out.println("3. local_async_greeting :" + result);
-      } else {
-        // print the greeting.
-        System.out.println(ex);
-      }
-      timeLatch.countDown();
-    });
-
-    await(timeLatch, 1, TimeUnit.SECONDS);
-    microservices.cluster().shutdown();
-  }
 
   @Test
   public void test_local_async_no_params() {
@@ -127,15 +32,17 @@ public class ServiceTest extends BaseTest {
         .services(new GreetingServiceImpl())
         .build();
 
-    // get a proxy to the service api.
-    GreetingService service = createProxy(microservices);
+    ServiceCall service = microservices.dispatcher().create();
 
     // call the service.
-    CompletableFuture<String> future = service.greetingNoParams();
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingNoParams").build());
 
     CountDownLatch timeLatch = new CountDownLatch(1);
-    future.whenComplete((result, ex) -> {
+    future.whenComplete((message, ex) -> {
       if (ex == null) {
+        System.out.println(message);
+        String result = message.data();
         assertTrue(result.equals("hello unknown"));
         // print the greeting.
         System.out.println("test_local_async_no_params :" + result);
@@ -148,91 +55,6 @@ public class ServiceTest extends BaseTest {
 
     await(timeLatch, 1, TimeUnit.SECONDS);
     microservices.cluster().shutdown();
-  }
-
-  @Test
-  public void test_remote_void_greeting() throws InterruptedException {
-    // Create microservices instance.
-    Microservices gateway = Microservices.builder()
-        .port(port.incrementAndGet())
-        .build();
-
-    Microservices.builder()
-        .seeds(gateway.cluster().address())
-        .services(new GreetingServiceImpl())
-        .build();
-
-    GreetingService service = gateway.proxy()
-        .api(GreetingService.class)
-        .timeout(Duration.ofSeconds(3))
-        .create();
-
-    // call the service.
-    service.greetingVoid(new GreetingRequest("joe"));
-
-    // send and forget so we have no way to know what happen
-    // but at least we didn't get exception :)
-    assertTrue(true);
-    System.out.println("test_remote_void_greeting done.");
-    
-
-    Thread.sleep(1000);
-  }
-
-  @Test
-  public void test_local_void_greeting() {
-    // Create microservices instance.
-    GreetingService service = Microservices.builder()
-        .port(port.incrementAndGet())
-        .services(new GreetingServiceImpl())
-        .build().proxy()
-        .api(GreetingService.class)
-        .create();
-
-    // call the service.
-    service.greetingVoid(new GreetingRequest("joe"));
-
-    // send and forget so we have no way to know what happen
-    // but at least we didn't get exception :)
-    assertTrue(true);
-    System.out.println("test_local_void_greeting done.");
-  }
-
-  @Test
-  public void test_remote_async_greeting_return_string() {
-    // Create microservices cluster.
-    Microservices provider = Microservices.builder()
-        .port(port.incrementAndGet())
-        .services(new GreetingServiceImpl())
-        .build();
-
-    // Create microservices cluster.
-    Microservices consumer = Microservices.builder()
-        .port(port.incrementAndGet())
-        .seeds(provider.cluster().address())
-        .build();
-
-    // get a proxy to the service api.
-    GreetingService service = createProxy(consumer);
-
-    // call the service.
-    CompletableFuture<String> future = service.greeting("joe");
-
-    CountDownLatch timeLatch = new CountDownLatch(1);
-    future.whenComplete((result, ex) -> {
-      if (ex == null) {
-        // print the greeting.
-        System.out.println("4. remote_async_greeting_return_string :" + result);
-        assertTrue(result.equals(" hello to: joe"));
-      } else {
-        // print the greeting.
-        System.out.println(ex);
-      }
-      timeLatch.countDown();
-    });
-    await(timeLatch, 1, TimeUnit.SECONDS);
-    provider.cluster().shutdown();
-    consumer.cluster().shutdown();
   }
 
   @Test
@@ -249,18 +71,122 @@ public class ServiceTest extends BaseTest {
         .seeds(provider.cluster().address())
         .build();
 
-    // get a proxy to the service api.
-    GreetingService service = createProxy(consumer);
+    ServiceCall service = consumer.dispatcher().create();
 
     // call the service.
-    CompletableFuture<String> future = service.greetingNoParams();
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingNoParams").build());
+
+    CountDownLatch timeLatch = new CountDownLatch(1);
+    future.whenComplete((message, ex) -> {
+      if (ex == null) {
+        System.out.println(message);
+        String result = message.data();
+        assertTrue(result.equals("hello unknown"));
+        // print the greeting.
+        System.out.println("test_local_async_no_params :" + result);
+      } else {
+        // print the greeting.
+        System.out.println(ex);
+      }
+      timeLatch.countDown();
+    });
+
+    await(timeLatch, 1, TimeUnit.SECONDS);
+    provider.cluster().shutdown();
+    consumer.cluster().shutdown();
+  }
+
+  @Test
+  public void test_remote_void_greeting() {
+    // Create microservices instance.
+    Microservices gateway = Microservices.builder()
+        .port(port.incrementAndGet())
+        .build();
+
+    Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .services(new GreetingServiceImpl())
+        .build();
+
+    ServiceCall service = gateway.dispatcher().create();
+
+    // call the service.
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingVoid")
+        .data(new GreetingRequest("joe"))
+        .build());
+
+    CountDownLatch timeLatch = new CountDownLatch(1);
+    future.whenComplete((success, error) -> {
+      if (error == null) {
+        System.out.println("void return: " + success);
+        assertTrue(success.data() == null);
+        timeLatch.countDown();
+      }
+    });
+    // send and forget so we have no way to know what happen
+    // but at least we didn't get exception :)
+    System.out.println("test_remote_void_greeting done.");
+    await(timeLatch, 1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void test_local_void_greeting() {
+    // Create microservices instance.
+    ServiceCall service = Microservices.builder()
+        .port(port.incrementAndGet())
+        .services(new GreetingServiceImpl())
+        .build().dispatcher().create();
+
+    // call the service.
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingVoid")
+        .data(new GreetingRequest("joe"))
+        .build());
+
+    CountDownLatch timeLatch = new CountDownLatch(1);
+    future.whenComplete((success, error) -> {
+      if (error == null) {
+        System.out.println("void return: " + success);
+        assertTrue(success.data() == null);
+        timeLatch.countDown();
+      }
+    });
+    // send and forget so we have no way to know what happen
+    // but at least we didn't get exception :)
+    System.out.println("test_local_void_greeting done.");
+    await(timeLatch, 1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void test_remote_async_greeting_return_string() {
+    // Create microservices cluster.
+    Microservices provider = Microservices.builder()
+        .port(port.incrementAndGet())
+        .services(new GreetingServiceImpl())
+        .build();
+
+    // Create microservices cluster.
+    Microservices consumer = Microservices.builder()
+        .port(port.incrementAndGet())
+        .seeds(provider.cluster().address())
+        .build();
+
+    ServiceCall service = consumer.dispatcher().create();
+
+    // call the service.
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greeting")
+        .data("joe")
+        .build());
 
     CountDownLatch timeLatch = new CountDownLatch(1);
     future.whenComplete((result, ex) -> {
       if (ex == null) {
         // print the greeting.
-        System.out.println("test_remote_async_greeting_no_params :" + result);
-        assertTrue(result.equals("hello unknown"));
+        System.out.println("4. remote_async_greeting_return_string :" + result);
+        assertTrue(result.data().equals(" hello to: joe"));
       } else {
         // print the greeting.
         System.out.println(ex);
@@ -272,6 +198,8 @@ public class ServiceTest extends BaseTest {
     consumer.cluster().shutdown();
   }
 
+
+
   @Test
   public void test_local_async_greeting_return_GreetingResponse() {
     // Create microservices cluster.
@@ -280,18 +208,21 @@ public class ServiceTest extends BaseTest {
         .services(new GreetingServiceImpl())
         .build();
 
-    // get a proxy to the service api.
-    GreetingService service = createProxy(microservices);
+    ServiceCall service = microservices.dispatcher().create();
 
     // call the service.
-    CompletableFuture<GreetingResponse> future = service.greetingRequest(new GreetingRequest("joe"));
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingRequest")
+        .data(new GreetingRequest("joe"))
+        .build());
 
     CountDownLatch timeLatch = new CountDownLatch(1);
     future.whenComplete((result, ex) -> {
       if (ex == null) {
-        assertTrue(result.getResult().equals(" hello to: joe"));
         // print the greeting.
-        System.out.println("5. remote_async_greeting_return_GreetingResponse :" + result);
+        System.out.println("test_local_async_greeting_return_GreetingResponse :" + result);
+        GreetingResponse data = result.data();
+        assertTrue(data.getResult().equals(" hello to: joe"));
       } else {
         // print the greeting.
         System.out.println(ex);
@@ -316,26 +247,27 @@ public class ServiceTest extends BaseTest {
         .seeds(provider.cluster().address())
         .build();
 
-    // get a proxy to the service api.
-    GreetingService service = createProxy(consumer);
+    ServiceCall service = consumer.dispatcher().create();
 
     // call the service.
-    CompletableFuture<GreetingResponse> future = service.greetingRequest(new GreetingRequest("joe"));
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingRequest")
+        .data(new GreetingRequest("joe"))
+        .build());
 
     CountDownLatch timeLatch = new CountDownLatch(1);
     future.whenComplete((result, ex) -> {
       if (ex == null) {
         // print the greeting.
-        System.out.println("6. remote_async_greeting_return_GreetingResponse :" + result.getResult());
-        // print the greeting.
-        assertTrue(result.getResult().equals(" hello to: joe"));
+        System.out.println("test_remote_async_greeting_return_GreetingResponse :" + result);
+        GreetingResponse data = result.data();
+        assertTrue(data.getResult().equals(" hello to: joe"));
       } else {
         // print the greeting.
         System.out.println(ex);
       }
       timeLatch.countDown();
     });
-
     await(timeLatch, 1, TimeUnit.SECONDS);
     provider.cluster().shutdown();
     consumer.cluster().shutdown();
@@ -344,31 +276,34 @@ public class ServiceTest extends BaseTest {
   @Test
   public void test_local_greeting_request_timeout_expires() {
     // Create microservices instance.
-    GreetingService service = Microservices.builder()
+    ServiceCall service = Microservices.builder()
         .port(port.incrementAndGet())
         .services(new GreetingServiceImpl())
         .build()
-        .proxy().api(GreetingService.class)
+        .dispatcher()
         .timeout(Duration.ofSeconds(1))
         .create();
 
     // call the service.
-    CompletableFuture<GreetingResponse> result =
-        service.greetingRequestTimeout(new GreetingRequest("joe", Duration.ofSeconds(2)));
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingRequestTimeout")
+        .data(new GreetingRequest("joe", Duration.ofSeconds(2)))
+        .build(), Duration.ofMillis(1));
 
     CountDownLatch timeLatch = new CountDownLatch(1);
-    result.whenComplete((success, error) -> {
+
+    future.whenComplete((success, error) -> {
       if (error != null) {
         // print the greeting.
         System.out.println("7. local_greeting_request_timeout_expires : " + error);
         assertTrue(error instanceof TimeoutException);
       } else {
-        assertTrue("7. failed", false);
+        fail();
       }
       timeLatch.countDown();
     });
 
-    await(timeLatch, 5, TimeUnit.SECONDS);
+    await(timeLatch, 1, TimeUnit.SECONDS);
   }
 
   @Test
@@ -385,17 +320,19 @@ public class ServiceTest extends BaseTest {
         .seeds(provider.cluster().address())
         .build();
 
-    // get a proxy to the service api.
-    GreetingService service = createProxy(consumer, Duration.ofSeconds(1));
-
+    ServiceCall service = consumer.dispatcher()
+        .timeout(Duration.ofSeconds(1))
+        .create();
 
     // call the service.
-    CompletableFuture<GreetingResponse> result =
-        service.greetingRequestTimeout(new GreetingRequest("joe", Duration.ofSeconds(4)));
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingRequestTimeout")
+        .data(new GreetingRequest("joe", Duration.ofSeconds(4)))
+        .build());
 
     CountDownLatch timeLatch = new CountDownLatch(1);
 
-    result.whenComplete((success, error) -> {
+    future.whenComplete((success, error) -> {
       if (error != null) {
         // print the greeting.
         System.out.println("8. remote_greeting_request_timeout_expires : " + error);
@@ -419,11 +356,17 @@ public class ServiceTest extends BaseTest {
         .services(new GreetingServiceImpl())
         .build();
 
-    // get a proxy to the service api.
-    GreetingService service = createProxy(microservices);
+
+    ServiceCall service = microservices.dispatcher()
+        .timeout(Duration.ofSeconds(1))
+        .create();
 
     // call the service.
-    CompletableFuture<Message> future = service.greetingMessage(Message.builder().data("joe").build());
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingMessage")
+        .data(Message.builder().data("joe").build())
+        .build(), Duration.ofMillis(1));
+
 
     CountDownLatch timeLatch = new CountDownLatch(1);
     future.whenComplete((result, ex) -> {
@@ -455,11 +398,14 @@ public class ServiceTest extends BaseTest {
         .seeds(provider.cluster().address())
         .build();
 
-    // get a proxy to the service api.
-    GreetingService service = createProxy(consumer);
+    ServiceCall service = consumer.dispatcher()
+        .create();
 
     // call the service.
-    CompletableFuture<Message> future = service.greetingMessage(Message.builder().data("joe").build());
+    CompletableFuture<Message> future = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingMessage")
+        .data(Message.builder().data("joe").build())
+        .build());
 
     CountDownLatch timeLatch = new CountDownLatch(1);
     future.whenComplete((result, ex) -> {
@@ -498,11 +444,19 @@ public class ServiceTest extends BaseTest {
         .services(new GreetingServiceImpl())
         .build();
 
-    GreetingService service = createProxy(gateway);
+    ServiceCall service = gateway.dispatcher()
+        .create();
 
-    CompletableFuture<Message> result1 = service.greetingMessage(Message.builder().data("joe").build());
-    CompletableFuture<Message> result2 = service.greetingMessage(Message.builder().data("joe").build());
+    // call the service.
+    CompletableFuture<Message> result1 = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingMessage")
+        .data(Message.builder().data("joe").build())
+        .build());
 
+    CompletableFuture<Message> result2 = service.invoke(ServiceCall
+        .request(SERVICE_NAME, "greetingMessage")
+        .data(Message.builder().data("joe").build())
+        .build());
 
     CompletableFuture<Void> combined = CompletableFuture.allOf(result1, result2);
     CountDownLatch timeLatch = new CountDownLatch(1);
@@ -534,12 +488,18 @@ public class ServiceTest extends BaseTest {
     // Create microservices instance cluster.
     Microservices provider1 = createProvider(gateway);
 
-    GreetingService service = createProxy(gateway);
+    ServiceCall service = provider1.dispatcher().create();
+
     CountDownLatch timeLatch = new CountDownLatch(1);
     try {
-      service.greeting("hello");
+      // call the service.
+      CompletableFuture<Message> future = service.invoke(ServiceCall
+          .request(SERVICE_NAME, "unknown")
+          .data(Message.builder().data("joe").build())
+          .build());
+
     } catch (Exception ex) {
-      assertTrue(ex.getMessage().equals("No reachable member with such service: greeting"));
+      assertTrue(ex.getMessage().equals("No reachable member with such service: unknown"));
       timeLatch.countDown();
     }
 
@@ -562,8 +522,9 @@ public class ServiceTest extends BaseTest {
         .seeds(provider.cluster().address())
         .build();
 
-    // Get a proxy to the service api.
-    GreetingService service = createProxy(consumer);
+    ServiceCall service = consumer.dispatcher().create();
+
+
 
     // Init params
     int warmUpCount = 1_000;
@@ -572,7 +533,12 @@ public class ServiceTest extends BaseTest {
 
     // Warm up
     for (int i = 0; i < warmUpCount; i++) {
-      CompletableFuture<Message> future = service.greetingMessage(Message.fromData("naive_stress_test"));
+      // call the service.
+      CompletableFuture<Message> future = service.invoke(ServiceCall
+          .request(SERVICE_NAME, "greetingMessage")
+          .data(Message.builder().data("naive_stress_test").build())
+          .build());
+
       future.whenComplete((success, error) -> {
         if (error == null) {
           warmUpLatch.countDown();
@@ -587,7 +553,11 @@ public class ServiceTest extends BaseTest {
     CountDownLatch countLatch = new CountDownLatch(count);
     long startTime = System.currentTimeMillis();
     for (int i = 0; i < count; i++) {
-      CompletableFuture<Message> future = service.greetingMessage(Message.fromData("naive_stress_test"));
+      CompletableFuture<Message> future = service.invoke(ServiceCall
+          .request(SERVICE_NAME, "greetingMessage")
+          .data(Message.builder().data("naive_stress_test").build())
+          .build());
+
       future.whenComplete((success, error) -> {
         if (error == null) {
           countLatch.countDown();
@@ -620,17 +590,24 @@ public class ServiceTest extends BaseTest {
         .build()
         .build();
 
-    CanaryService service = gateway.proxy()
+    ServiceCall service = gateway.dispatcher()
         .router(CanaryTestingRouter.class)
-        .api(CanaryService.class).create();
+        .create();
 
     AtomicInteger count = new AtomicInteger(0);
     AtomicInteger responses = new AtomicInteger(0);
     CountDownLatch timeLatch = new CountDownLatch(1);
+
     for (int i = 0; i < 100; i++) {
-      service.greeting("joe").whenComplete((success, error) -> {
+      // call the service.
+      CompletableFuture<Message> future = service.invoke(ServiceCall
+          .request(CANARY_SERVICE, "greeting")
+          .data("joe")
+          .build());
+
+      future.whenComplete((success, error) -> {
         responses.incrementAndGet();
-        if (success.startsWith("B")) {
+        if (success.data().toString().startsWith("B")) {
           count.incrementAndGet();
           if ((responses.get() == 100) && (60 < count.get() && count.get() < 80)) {
             timeLatch.countDown();
@@ -643,17 +620,76 @@ public class ServiceTest extends BaseTest {
     assertTrue((responses.get() == 100) && (60 < count.get() && count.get() < 80));
   }
 
-  private GreetingService createProxy(Microservices gateway) {
-    return gateway.proxy()
-        .api(GreetingService.class) // create proxy for GreetingService API
-        .create();
+  @Test
+  public void test_dispatcher_remote_greeting_request_completes_before_timeout() {
+    Duration duration = Duration.ofSeconds(1);
+
+    // Create microservices instance.
+    Microservices gateway = Microservices.builder()
+        .port(port.incrementAndGet())
+        .build();
+
+    Microservices.builder()
+        .seeds(gateway.cluster().address())
+        .services(new GreetingServiceImpl())
+        .build();
+
+    ServiceCall service = gateway.dispatcher().timeout(Duration.ofSeconds(3)).create();
+
+    CompletableFuture<Message> result = service.invoke(ServiceCall.request(
+        "io.scalecube.services.GreetingService", "greetingRequest")
+        .data(new GreetingRequest("joe"))
+        .build());
+
+    CountDownLatch timeLatch = new CountDownLatch(1);
+    result.whenComplete((success, error) -> {
+      if (error == null) {
+        System.out.println(success);
+        GreetingResponse greetings = success.data();
+        // print the greeting.
+        System.out.println("1. greeting_request_completes_before_timeout : " + greetings.getResult());
+        assertTrue(greetings.getResult().equals(" hello to: joe"));
+        timeLatch.countDown();
+      } else {
+        System.out.println("1. FAILED! - greeting_request_completes_before_timeout reached timeout: " + error);
+        assertTrue(error.toString(), false);
+        timeLatch.countDown();
+      }
+    });
+    await(timeLatch, 10, TimeUnit.SECONDS);
   }
 
-  private GreetingService createProxy(Microservices micro, Duration duration) {
-    return micro.proxy()
-        .api(GreetingService.class) // create proxy for GreetingService API
-        .timeout(duration)
-        .create();
+  @Test
+  public void test_dispatcher_local_greeting_request_completes_before_timeout() {
+
+    Microservices gateway = Microservices.builder()
+        .services(new GreetingServiceImpl())
+        .build();
+
+    ServiceCall service = gateway.dispatcher().timeout(Duration.ofSeconds(3)).create();
+
+    CompletableFuture<Message> result = service.invoke(
+        ServiceCall.request(
+            "io.scalecube.services.GreetingService", "greetingRequest")
+            .data(new GreetingRequest("joe"))
+            .build());
+
+    CountDownLatch timeLatch = new CountDownLatch(1);
+    result.whenComplete((success, error) -> {
+      if (error == null) {
+        System.out.println(success);
+        GreetingResponse greetings = success.data();
+        // print the greeting.
+        System.out.println("1. greeting_request_completes_before_timeout : " + greetings.getResult());
+        assertTrue(greetings.getResult().equals(" hello to: joe"));
+        timeLatch.countDown();
+      } else {
+        System.out.println("1. FAILED! - greeting_request_completes_before_timeout reached timeout: " + error);
+        assertTrue(error.toString(), false);
+        timeLatch.countDown();
+      }
+    });
+    await(timeLatch, 10, TimeUnit.SECONDS);
   }
 
   private Microservices createProvider(Microservices gateway) {

--- a/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
@@ -17,7 +17,7 @@ public class CanaryTestingRouter implements Router {
   }
 
   @Override
-  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition) {
+  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition, Object data) {
     RandomCollection<ServiceInstance> weightedRandom = new RandomCollection<>();
     serviceRegistry.serviceLookup(serviceDefinition.serviceName()).stream().forEach(instance -> {
       weightedRandom.add(

--- a/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
+++ b/services/src/test/java/io/scalecube/services/a/b/testing/CanaryTestingRouter.java
@@ -1,9 +1,10 @@
 package io.scalecube.services.a.b.testing;
 
-import io.scalecube.services.ServiceDefinition;
+import io.scalecube.services.ServiceHeaders;
 import io.scalecube.services.ServiceInstance;
 import io.scalecube.services.ServiceRegistry;
 import io.scalecube.services.routing.Router;
+import io.scalecube.transport.Message;
 
 import java.util.Optional;
 
@@ -17,9 +18,10 @@ public class CanaryTestingRouter implements Router {
   }
 
   @Override
-  public Optional<ServiceInstance> route(ServiceDefinition serviceDefinition, Object data) {
+  public Optional<ServiceInstance> route(Message request) {
+    String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
     RandomCollection<ServiceInstance> weightedRandom = new RandomCollection<>();
-    serviceRegistry.serviceLookup(serviceDefinition.serviceName()).stream().forEach(instance -> {
+    serviceRegistry.serviceLookup(serviceName).stream().forEach(instance -> {
       weightedRandom.add(
           Double.valueOf(instance.tags().get("Weight")),
           instance);


### PR DESCRIPTION
Added support for service calls using dispatchers

the service call is a generic way to call service interface using a message while not using a java proxy api.

this enables more generic approach to address services by service-name and service-method-names and not be strongly restricted by a java proxy interface.

it also enables to set timeout per service request (java proxy does not allow this unless you add this as parameter)

