### PR TITLE
Improve reliability of GossipProtocol under adverse conditions (message loss 50%)

### DIFF
--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipConfig.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipConfig.java
@@ -2,15 +2,18 @@ package io.scalecube.cluster.gossip;
 
 public final class GossipConfig {
 
-  public static final int DEFAULT_GOSSIP_INTERVAL = 200;
+  public static final long DEFAULT_GOSSIP_INTERVAL = 200;
   public static final int DEFAULT_GOSSIP_FANOUT = 3;
+  public static final int DEFAULT_GOSSIP_FACTOR = 2;
 
-  private final int gossipInterval;
+  private final long gossipInterval;
   private final int gossipFanout;
+  private final int gossipFactor;
 
   private GossipConfig(Builder builder) {
     this.gossipFanout = builder.gossipFanout;
     this.gossipInterval = builder.gossipInterval;
+    this.gossipFactor = builder.gossipFactor;
   }
 
   public static GossipConfig defaultConfig() {
@@ -25,29 +28,42 @@ public final class GossipConfig {
     return gossipFanout;
   }
 
-  public int getGossipInterval() {
+  public long getGossipInterval() {
     return gossipInterval;
+  }
+
+  public int getGossipFactor() {
+    return gossipFactor;
   }
 
   @Override
   public String toString() {
-    return "GossipConfig{gossipInterval=" + gossipInterval + ", gossipFanout=" + gossipFanout + '}';
+    return "GossipConfig{gossipInterval=" + gossipInterval
+        + ", gossipFanout=" + gossipFanout
+        + ", gossipFactor=" + gossipFactor
+        + '}';
   }
 
   public static final class Builder {
 
-    private int gossipInterval = DEFAULT_GOSSIP_INTERVAL;
+    private long gossipInterval = DEFAULT_GOSSIP_INTERVAL;
     private int gossipFanout = DEFAULT_GOSSIP_FANOUT;
+    private int gossipFactor = DEFAULT_GOSSIP_FACTOR;
 
     private Builder() {}
 
-    public Builder gossipInterval(int gossipInterval) {
+    public Builder gossipInterval(long gossipInterval) {
       this.gossipInterval = gossipInterval;
       return this;
     }
 
     public Builder gossipFanout(int gossipFanout) {
       this.gossipFanout = gossipFanout;
+      return this;
+    }
+
+    public Builder gossipFactor(int gossipFactor) {
+      this.gossipFactor = gossipFactor;
       return this;
     }
 

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
@@ -306,8 +306,8 @@ public final class GossipProtocol implements IGossipProtocol {
     return periodsToKeep() * config.getGossipInterval();
   }
   
-  private int ceilLog2(int n) {
-    return 32 - Integer.numberOfLeadingZeros(n) /* ceil[log2(N)] */;
+  private int ceilLog2(int num) {
+    return 32 - Integer.numberOfLeadingZeros(num) /* ceil[log2(N)] */;
   }
 
 }

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
@@ -1,11 +1,11 @@
 package io.scalecube.cluster.gossip;
 
+import io.scalecube.cluster.Member;
+
 import com.google.common.base.Preconditions;
 
 import java.util.HashSet;
 import java.util.Set;
-
-import io.scalecube.cluster.Member;
 
 /** Data related to gossip, maintained locally on each node. */
 final class GossipState {

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
@@ -2,6 +2,11 @@ package io.scalecube.cluster.gossip;
 
 import com.google.common.base.Preconditions;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import io.scalecube.cluster.Member;
+
 /** Data related to gossip, maintained locally on each node. */
 final class GossipState {
 
@@ -10,6 +15,9 @@ final class GossipState {
 
   /** Local gossip period when gossip was received for the first time. */
   private final long infectionPeriod;
+
+  /** Set of members this gossip was received from. */
+  private final Set<Member> infected = new HashSet<>();
 
   GossipState(Gossip gossip, long infectionPeriod) {
     Preconditions.checkArgument(gossip != null);
@@ -25,8 +33,19 @@ final class GossipState {
     return infectionPeriod;
   }
 
+  public void addToInfected(Member member) {
+    infected.add(member);
+  }
+
+  public boolean isInfected(Member member) {
+    return infected.contains(member);
+  }
+
   @Override
   public String toString() {
-    return "GossipState{gossip=" + gossip + ", infectionPeriod=" + infectionPeriod + '}';
+    return "GossipState{gossip=" + gossip
+        + ", infectionPeriod=" + infectionPeriod
+        + ", infected=" + infected
+        + '}';
   }
 }

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipState.java
@@ -1,11 +1,6 @@
 package io.scalecube.cluster.gossip;
 
-import io.scalecube.cluster.Member;
-
 import com.google.common.base.Preconditions;
-
-import java.util.HashSet;
-import java.util.Set;
 
 /** Data related to gossip, maintained locally on each node. */
 final class GossipState {
@@ -13,14 +8,8 @@ final class GossipState {
   /** Target gossip. */
   private final Gossip gossip;
 
-  /** Local gossip period when gossip was heard for first time. */
+  /** Local gossip period when gossip was received for the first time. */
   private final long infectionPeriod;
-
-  /** How many times gossip was sent, incremented on each send. */
-  private int spreadCount = 0;
-
-  /** Set of members this gossip was received from or sent to. */
-  private Set<Member> infected = new HashSet<>();
 
   GossipState(Gossip gossip, long infectionPeriod) {
     Preconditions.checkArgument(gossip != null);
@@ -36,28 +25,8 @@ final class GossipState {
     return infectionPeriod;
   }
 
-  public void addToInfected(Member member) {
-    infected.add(member);
-  }
-
-  public boolean isInfected(Member member) {
-    return infected.contains(member);
-  }
-
-  public void incrementSpreadCount() {
-    spreadCount++;
-  }
-
-  public int spreadCount() {
-    return spreadCount;
-  }
-
   @Override
   public String toString() {
-    return "GossipState{gossip=" + gossip
-        + ", infectionPeriod=" + infectionPeriod
-        + ", spreadCount=" + spreadCount
-        + ", infected=" + infected
-        + '}';
+    return "GossipState{gossip=" + gossip + ", infectionPeriod=" + infectionPeriod + '}';
   }
 }

--- a/cluster/src/test/java/io/scalecube/cluster/gossip/GossipProtocolTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/gossip/GossipProtocolTest.java
@@ -12,10 +12,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.LongSummaryStatistics;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
@@ -27,41 +30,74 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @RunWith(Parameterized.class)
 public class GossipProtocolTest {
 
-  @Parameterized.Parameters(name = "N={0}, Plost={1}%, Tmean={2}ms, T={3}ms")
+  private static final Logger LOGGER = LoggerFactory.getLogger(GossipProtocolTest.class);
+
+  private static List<Object[]> experiments = Arrays.asList(new Object[][] {
+//      N  , L  ,  D      // N - num of nodes, L - msg loss percent, D - msg mean delay (ms)
+      { 2  , 0  ,  2   }, // warm up
+      { 2  , 0  ,  2   },
+      { 3  , 0  ,  2   },
+      { 5  , 0  ,  2   },
+      { 10 , 0  ,  2   },
+      { 10 , 10 ,  2   },
+      { 10 , 25 ,  2   },
+      { 10 , 25 ,  100 },
+      { 10 , 50 ,  2   },
+      { 50 , 0  ,  2   },
+      { 50 , 10 ,  2   },
+      { 50 , 10 ,  100 },
+  });
+
+  // Makes tests run longer since always awaits for maximum gossip lifetime, but performs more checks
+  private static final boolean awaitFullCompletion = true;
+
+  // Allow to configure gossip settings other than defaults
+  private static final long gossipInterval /* ms */ = GossipConfig.DEFAULT_GOSSIP_INTERVAL;
+  private static final int gossipFanout = GossipConfig.DEFAULT_GOSSIP_FANOUT;
+  private static final int gossipFactor = GossipConfig.DEFAULT_GOSSIP_FACTOR;
+
+
+  // Uncomment and modify params to run single experiment repeatedly
+//  static {
+//    int repeatCount = 1000;
+//    int membersNum = 10;
+//    int lossPercent = 50; //%
+//    int meanDelay = 2; //ms
+//    experiments = new ArrayList<>(repeatCount + 1);
+//    experiments.add(new Object[] {2, 0, 2}); // add warm up experiment
+//    for (int i = 0; i < repeatCount; i++) {
+//      experiments.add(new Object[] {membersNum, lossPercent,  meanDelay});
+//    }
+//  }
+
+  @Parameterized.Parameters(name = "N={0}, Ploss={1}%, Tmean={2}ms")
   public static List<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-//        N  , L  ,  D   , T         // N - num of nodes, L - loss percent, D - mean delay (ms), T - timeout (ms)
-        { 2  , 0  ,  2   , 1_000  }, // warm up
-        { 2  , 0  ,  2   ,   500  },
-        { 3  , 0  ,  2   ,   500  },
-        { 5  , 0  ,  2   ,   800  },
-        { 10 , 0  ,  2   , 1_000  },
-        { 10 , 25 ,  2   , 2_000  },
-        { 10 , 50 ,  2   , 4_000  },
-        { 50 , 0  ,  2   , 5_000  },
-        { 50 , 10  , 300 , 10_000 },
-    });
+    return experiments;
   }
 
   private final int membersNum;
-  private final int lostPercent;
+  private final int lossPercent;
   private final int meanDelay;
-  private final int timeout;
 
-  public GossipProtocolTest(int membersNum, int lostPercent, int meanDelay, int timeout) {
+  public GossipProtocolTest(int membersNum, int lossPercent, int meanDelay) {
     this.membersNum = membersNum;
-    this.lostPercent = lostPercent;
+    this.lossPercent = lossPercent;
     this.meanDelay = meanDelay;
-    this.timeout = timeout;
   }
 
   @Test
   public void testGossipProtocol() throws Exception {
     // Init gossip protocol instances
-    List<GossipProtocol> gossipProtocols = initGossipProtocols(membersNum, lostPercent, meanDelay);
+    List<GossipProtocol> gossipProtocols = initGossipProtocols(membersNum, lossPercent, meanDelay);
 
     // Subscribe on gossips
-    long time = 0;
+    long disseminationTime = 0;
+    long awaitCompletionTime = 0;
+    LongSummaryStatistics messageSentStatsDissemination = null;
+    LongSummaryStatistics messageLostStatsDissemination = null;
+    LongSummaryStatistics messageSentStatsOverall = null;
+    LongSummaryStatistics messageLostStatsOverall = null;
+    long gossipLifetime = gossipProtocols.get(0).gossipLifetime();
     try {
       final String gossipData = "test gossip - " + ThreadLocalRandom.current().nextLong();
       final CountDownLatch latch = new CountDownLatch(membersNum - 1);
@@ -74,7 +110,7 @@ public class GossipProtocolTest {
             if (firstTimeAdded) {
               latch.countDown();
             } else {
-              System.out.println("Delivered gossip twice to: " + protocol.getTransport().address());
+              LOGGER.error("Delivered gossip twice to: {}", protocol.getTransport().address());
               doubleDelivery.set(true);
             }
           }
@@ -84,16 +120,60 @@ public class GossipProtocolTest {
       // Spread gossip, measure and verify delivery metrics
       long start = System.currentTimeMillis();
       gossipProtocols.get(0).spread(Message.fromData(gossipData));
-      latch.await(2 * timeout, TimeUnit.MILLISECONDS); // Await double timeout
-      time = System.currentTimeMillis() - start;
-      Assert.assertFalse("Delivered gossip twice to same member", doubleDelivery.get());
+      latch.await(2 * gossipLifetime, TimeUnit.MILLISECONDS); // Await for double gossip lifetime
+      disseminationTime = System.currentTimeMillis() - start;
+      messageSentStatsDissemination = computeMessageSentStats(gossipProtocols);
+      messageLostStatsDissemination = computeMessageLostStats(gossipProtocols);
       Assert.assertEquals("Not all members received gossip", membersNum - 1, receivers.size());
-      Assert.assertTrue("Time " + time + "ms is bigger then expected " + timeout + "ms", time < timeout);
+      Assert.assertTrue("Too long dissemination time " + disseminationTime
+              + "ms (timeout " + gossipLifetime + "ms)", disseminationTime < gossipLifetime);
+
+      // Await gossip lifetime plus few gossip intervals too ensure gossip is fully spread
+      if (awaitFullCompletion) {
+        awaitCompletionTime = gossipLifetime - disseminationTime + 3 * gossipInterval;
+        Thread.sleep(awaitCompletionTime);
+
+        messageSentStatsOverall = computeMessageSentStats(gossipProtocols);
+        messageLostStatsOverall = computeMessageLostStats(gossipProtocols);
+      }
+      Assert.assertFalse("Delivered gossip twice to same member", doubleDelivery.get());
     } finally {
+      // Print results
+      LOGGER.info("[N={}, Ploss={}%, Tmean={}ms] Gossip dissemination time: {} ms (max {} ms)",
+          membersNum, lossPercent, meanDelay, disseminationTime, gossipLifetime);
+      LOGGER.info("[N={}, Ploss={}%, Tmean={}ms] Message sent until dissemination stats: {}",
+          membersNum, lossPercent, meanDelay, messageSentStatsDissemination);
+      LOGGER.info("[N={}, Ploss={}%, Tmean={}ms] Message lost until dissemination stats: {}",
+          membersNum, lossPercent, meanDelay, messageLostStatsDissemination);
+      if (awaitFullCompletion) {
+        LOGGER.info("[N={}, Ploss={}%, Tmean={}ms] Message sent total stats (after await for {} ms): {}",
+            membersNum, lossPercent, meanDelay, awaitCompletionTime, messageSentStatsOverall);
+        LOGGER.info("[N={}, Ploss={}%, Tmean={}ms] Message lost total stats (after await for {} ms): {}",
+            membersNum, lossPercent, meanDelay, awaitCompletionTime, messageLostStatsOverall);
+      }
+
       // Destroy gossip protocol instances
       destroyGossipProtocols(gossipProtocols);
-      System.out.println("Gossip dissemination time: " + time + " ms");
+
     }
+  }
+
+  private LongSummaryStatistics computeMessageSentStats(List<GossipProtocol> gossipProtocols) {
+    List<Long> messageSentPerNode = new ArrayList<>(gossipProtocols.size());
+    for (GossipProtocol gossipProtocol : gossipProtocols) {
+      Transport transport = (Transport) gossipProtocol.getTransport();
+      messageSentPerNode.add(transport.totalMessageSentCount());
+    }
+    return messageSentPerNode.stream().mapToLong(v -> v).summaryStatistics();
+  }
+
+  private LongSummaryStatistics computeMessageLostStats(List<GossipProtocol> gossipProtocols) {
+    List<Long> messageLostPerNode = new ArrayList<>(gossipProtocols.size());
+    for (GossipProtocol gossipProtocol : gossipProtocols) {
+      Transport transport = (Transport) gossipProtocol.getTransport();
+      messageLostPerNode.add(transport.totalMessageLostCount());
+    }
+    return messageLostPerNode.stream().mapToLong(v -> v).summaryStatistics();
   }
 
   private List<GossipProtocol> initGossipProtocols(int count, int lostPercent, int meanDelay) {
@@ -128,7 +208,12 @@ public class GossipProtocolTest {
 
   private GossipProtocol initGossipProtocol(Transport transport, List<Address> members) {
     IMembershipProtocol dummyMembership = new DummyMembershipProtocol(transport.address(), members);
-    GossipProtocol gossipProtocol = new GossipProtocol(transport, dummyMembership, GossipConfig.defaultConfig());
+    GossipConfig gossipConfig = GossipConfig.builder()
+        .gossipFanout(gossipFanout)
+        .gossipInterval(gossipInterval)
+        .gossipFactor(gossipFactor)
+        .build();
+    GossipProtocol gossipProtocol = new GossipProtocol(transport, dummyMembership, gossipConfig);
     gossipProtocol.start();
     return gossipProtocol;
   }
@@ -149,7 +234,7 @@ public class GossipProtocolTest {
     try {
       CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])).get(30, TimeUnit.SECONDS);
     } catch (Exception ignore) {
-      System.out.println("Failed to await transport termination");
+      LOGGER.warn("Failed to await transport termination");
     }
 
     // Await a bit

--- a/cluster/src/test/java/io/scalecube/cluster/gossip/GossipProtocolTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/gossip/GossipProtocolTest.java
@@ -30,6 +30,7 @@ public class GossipProtocolTest {
   @Parameterized.Parameters(name = "N={0}, Plost={1}%, Tmean={2}ms, T={3}ms")
   public static List<Object[]> data() {
     return Arrays.asList(new Object[][] {
+//        N  , L  ,  D   , T         // N - num of nodes, L - loss percent, D - mean delay (ms), T - timeout (ms)
         { 2  , 0  ,  2   , 1_000  }, // warm up
         { 2  , 0  ,  2   ,   500  },
         { 3  , 0  ,  2   ,   500  },
@@ -47,7 +48,7 @@ public class GossipProtocolTest {
   private final int meanDelay;
   private final int timeout;
 
-  public GossipProtocolTest(Integer membersNum, Integer lostPercent, Integer meanDelay, Integer timeout) {
+  public GossipProtocolTest(int membersNum, int lostPercent, int meanDelay, int timeout) {
     this.membersNum = membersNum;
     this.lostPercent = lostPercent;
     this.meanDelay = meanDelay;

--- a/transport/src/main/java/io/scalecube/transport/Transport.java
+++ b/transport/src/main/java/io/scalecube/transport/Transport.java
@@ -244,6 +244,30 @@ public final class Transport implements ITransport {
     }
   }
 
+  /**
+   * Returns total message sent count computed by network emulator. If network emulator is disabled returns zero.
+   */
+  public long totalMessageSentCount() {
+    if (config.isUseNetworkEmulator()) {
+      return networkEmulatorHandler.totalMessageSentCount();
+    } else {
+      LOGGER.warn("Noop on 'totalMessageSentCount()' since network emulator is disabled");
+      return 0;
+    }
+  }
+
+  /**
+   * Returns total message lost count computed by network emulator. If network emulator is disabled returns zero.
+   */
+  public long totalMessageLostCount() {
+    if (config.isUseNetworkEmulator()) {
+      return networkEmulatorHandler.totalMessageLostCount();
+    } else {
+      LOGGER.warn("Noop on 'totalMessageLostCount()' since network emulator is disabled");
+      return 0;
+    }
+  }
+
   @Override
   public final void stop() {
     stop(COMPLETED_PROMISE);
@@ -353,7 +377,7 @@ public final class Transport implements ITransport {
       // Register logger and cleanup listener
       connectFuture.addListener((ChannelFutureListener) channelFuture -> {
         if (channelFuture.isSuccess()) {
-          LOGGER.info("Connected from {} to {}: {}", Transport.this.address, address, channelFuture.channel());
+          LOGGER.debug("Connected from {} to {}: {}", Transport.this.address, address, channelFuture.channel());
         } else {
           LOGGER.warn("Failed to connect from {} to {}", Transport.this.address, address);
           outgoingChannels.delete(address);

--- a/transport/src/main/java/io/scalecube/transport/Transport.java
+++ b/transport/src/main/java/io/scalecube/transport/Transport.java
@@ -189,7 +189,7 @@ public final class Transport implements ITransport {
   public void setDefaultNetworkSettings(int lostPercent, int meanDelay) {
     if (config.isUseNetworkEmulator()) {
       networkEmulatorHandler.setDefaultNetworkSettings(lostPercent, meanDelay);
-      LOGGER.info("Set default network settings (loss={}%, mean={}ms)");
+      LOGGER.info("Set default network settings (loss={}%, mean={}ms)", lostPercent, meanDelay);
     } else {
       LOGGER.warn("Noop on 'setDefaultNetworkSettings({},{})' since network emulator is disabled",
           lostPercent, meanDelay);

--- a/transport/src/test/java/io/scalecube/transport/TransportTest.java
+++ b/transport/src/test/java/io/scalecube/transport/TransportTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.LongStream;
 
 public class TransportTest extends BaseTest {
-  static final Logger LOGGER = LoggerFactory.getLogger(TransportTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(TransportTest.class);
 
   private Transport client;
   private Transport server;


### PR DESCRIPTION
Improvements:
* Do not track infected members and actually allow to resend same gossip from one member to same another member several times (in case of message loss I don't know either first time was delivered and can't mark him as infected).
* Introduced additional gossip config param `gossipFactor` and make to compute max rounds for spread gossips as `gossipFactor * ceilLog2(N)` which seems to be much more reliable settings.
* Select members to spread gossip sequentially and shuffle members once reached end of the list.
* Compute message sent stats and message lost stats at NetworkEmulator and print aggregated stats.

