### PR TITLE
fix issue #171 Binding transport to IPv6 address causes

### DIFF
--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
@@ -8,6 +8,7 @@ import io.scalecube.cluster.membership.MemberStatus;
 import io.scalecube.cluster.membership.MembershipEvent;
 import io.scalecube.transport.Transport;
 import io.scalecube.transport.Message;
+import io.scalecube.transport.ThreadFactory;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -88,8 +89,7 @@ public final class FailureDetector implements IFailureDetector {
     this.membership = membership;
     this.config = config;
     String nameFormat = "sc-fdetector-" + transport.address().toString();
-    this.executor = Executors.newSingleThreadScheduledExecutor(
-        new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build());
+    this.executor = ThreadFactory.singleScheduledExecutorService(nameFormat);
     this.scheduler = Schedulers.from(executor);
   }
 

--- a/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
+++ b/cluster/src/main/java/io/scalecube/cluster/fdetector/FailureDetector.java
@@ -89,7 +89,7 @@ public final class FailureDetector implements IFailureDetector {
     this.membership = membership;
     this.config = config;
     String nameFormat = "sc-fdetector-" + transport.address().toString();
-    this.executor = ThreadFactory.singleScheduledExecutorService(nameFormat);
+    this.executor = ThreadFactory.newSingleScheduledExecutorService(nameFormat);
     this.scheduler = Schedulers.from(executor);
   }
 

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
@@ -88,7 +88,7 @@ public final class GossipProtocol implements IGossipProtocol {
     this.membership = membership;
     this.config = config;
     String nameFormat = "sc-gossip-" + transport.address().toString();
-    this.executor = ThreadFactory.singleScheduledExecutorService(nameFormat);
+    this.executor = ThreadFactory.newSingleScheduledExecutorService(nameFormat);
     this.scheduler = Schedulers.from(executor);
   }
 

--- a/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/gossip/GossipProtocol.java
@@ -8,6 +8,7 @@ import io.scalecube.cluster.membership.IMembershipProtocol;
 import io.scalecube.cluster.membership.MembershipEvent;
 import io.scalecube.transport.Transport;
 import io.scalecube.transport.Message;
+import io.scalecube.transport.ThreadFactory;
 
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -87,8 +88,7 @@ public final class GossipProtocol implements IGossipProtocol {
     this.membership = membership;
     this.config = config;
     String nameFormat = "sc-gossip-" + transport.address().toString();
-    this.executor = Executors.newSingleThreadScheduledExecutor(
-        new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build());
+    this.executor = ThreadFactory.singleScheduledExecutorService(nameFormat);
     this.scheduler = Schedulers.from(executor);
   }
 

--- a/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocol.java
@@ -105,7 +105,7 @@ public final class MembershipProtocol implements IMembershipProtocol {
     this.config = config;
     Member member = new Member(IdGenerator.generateId(), transport.address(), config.getMetadata());
     this.memberRef = new AtomicReference<>(member);
-    this.executor = ThreadFactory.singleScheduledExecutorService("sc-membership-" + transport.address().toString());
+    this.executor = ThreadFactory.newSingleScheduledExecutorService("sc-membership-" + transport.address().toString());
     this.scheduler = Schedulers.from(executor);
     this.seedMembers = cleanUpSeedMembers(config.getSeedMembers());
   }

--- a/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocol.java
@@ -105,7 +105,7 @@ public final class MembershipProtocol implements IMembershipProtocol {
     Member member = new Member(IdGenerator.generateId(), transport.address(), config.getMetadata());
     this.memberRef = new AtomicReference<>(member);
 
-    String nameFormat = "sc-membership-" + transport.address().toString();
+    String nameFormat = "sc-membership-" + transport.address().toString().replaceAll("%", "-");
     this.executor = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build());
 

--- a/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocol.java
+++ b/cluster/src/main/java/io/scalecube/cluster/membership/MembershipProtocol.java
@@ -11,6 +11,7 @@ import io.scalecube.cluster.gossip.IGossipProtocol;
 import io.scalecube.transport.Address;
 import io.scalecube.transport.Transport;
 import io.scalecube.transport.Message;
+import io.scalecube.transport.ThreadFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -104,11 +105,7 @@ public final class MembershipProtocol implements IMembershipProtocol {
     this.config = config;
     Member member = new Member(IdGenerator.generateId(), transport.address(), config.getMetadata());
     this.memberRef = new AtomicReference<>(member);
-
-    String nameFormat = "sc-membership-" + transport.address().toString().replaceAll("%", "-");
-    this.executor = Executors.newSingleThreadScheduledExecutor(
-        new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build());
-
+    this.executor = ThreadFactory.singleScheduledExecutorService("sc-membership-" + transport.address().toString());
     this.scheduler = Schedulers.from(executor);
     this.seedMembers = cleanUpSeedMembers(config.getSeedMembers());
   }

--- a/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
@@ -15,7 +15,7 @@ public class MembersipProtocolTest extends BaseTest{
     
     Address address = Address.create("/fe80:0:0:0:8cf6:f5c8:c946:2c30%eno1", 4001);
     String nameFormat = "sc-membership-" + address.toString();
-    ThreadFactory.singleScheduledExecutorService(nameFormat);
+    ThreadFactory.newSingleScheduledExecutorService(nameFormat);
 
     assertTrue(true); // if we reached here no IllegalFormatConversionException is thrown.
   }

--- a/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
@@ -13,9 +13,11 @@ public class MembersipProtocolTest extends BaseTest{
   @Test
   public void test_ipv6_thread_factory_addressing(){
     
+    ThreadFactory factory = new ThreadFactory();
+    
     Address address = Address.create("/fe80:0:0:0:8cf6:f5c8:c946:2c30%eno1", 4001);
     String nameFormat = "sc-membership-" + address.toString();
-    ThreadFactory.newSingleScheduledExecutorService(nameFormat);
+    factory.newSingleScheduledExecutorService(nameFormat);
 
     assertTrue(true); // if we reached here no IllegalFormatConversionException is thrown.
   }

--- a/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
@@ -4,12 +4,9 @@ import static org.junit.Assert.assertTrue;
 
 import io.scalecube.testlib.BaseTest;
 import io.scalecube.transport.Address;
-
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.scalecube.transport.ThreadFactory;
 
 import org.junit.Test;
-
-import java.util.concurrent.Executors;
 
 public class MembersipProtocolTest extends BaseTest{
 
@@ -17,10 +14,9 @@ public class MembersipProtocolTest extends BaseTest{
   public void test_ipv6_thread_factory_addressing(){
     
     Address address = Address.create("/fe80:0:0:0:8cf6:f5c8:c946:2c30%eno1", 4001);
-    String nameFormat = "sc-membership-" + address.toString().replaceAll("%", "-");
-    Executors.newSingleThreadScheduledExecutor(
-        new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build());
-    
+    String nameFormat = "sc-membership-" + address.toString();
+    ThreadFactory.singleScheduledExecutorService(nameFormat);
+
     assertTrue(true); // if we reached here no IllegalFormatConversionException is thrown.
   }
 }

--- a/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
+++ b/cluster/src/test/java/io/scalecube/cluster/membership/MembersipProtocolTest.java
@@ -1,0 +1,26 @@
+package io.scalecube.cluster.membership;
+
+import static org.junit.Assert.assertTrue;
+
+import io.scalecube.testlib.BaseTest;
+import io.scalecube.transport.Address;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.junit.Test;
+
+import java.util.concurrent.Executors;
+
+public class MembersipProtocolTest extends BaseTest{
+
+  @Test
+  public void test_ipv6_thread_factory_addressing(){
+    
+    Address address = Address.create("/fe80:0:0:0:8cf6:f5c8:c946:2c30%eno1", 4001);
+    String nameFormat = "sc-membership-" + address.toString().replaceAll("%", "-");
+    Executors.newSingleThreadScheduledExecutor(
+        new ThreadFactoryBuilder().setNameFormat(nameFormat).setDaemon(true).build());
+    
+    assertTrue(true); // if we reached here no IllegalFormatConversionException is thrown.
+  }
+}

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -3,6 +3,7 @@ package io.scalecube.services;
 import io.scalecube.services.routing.Router;
 import io.scalecube.transport.Message;
 import io.scalecube.transport.Message.Builder;
+import io.scalecube.transport.ThreadFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -24,7 +24,7 @@ public class ServiceCall {
    * used to complete the request future with timeout exception in case no response comes from service.
    */
   private static final ScheduledExecutorService delayer =
-      ThreadFactory.singleScheduledExecutorService("sc-services-timeout");
+      ThreadFactory.newSingleScheduledExecutorService("sc-services-timeout");
 
   private Duration timeout;
   private Router router;

--- a/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
+++ b/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
@@ -3,6 +3,7 @@ package io.scalecube.services;
 import io.scalecube.services.routing.Router;
 import io.scalecube.services.routing.RouterFactory;
 import io.scalecube.transport.Message;
+import io.scalecube.transport.ThreadFactory;
 
 import com.google.common.reflect.Reflection;
 

--- a/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
+++ b/services/src/main/java/io/scalecube/services/ServiceProxyFactory.java
@@ -27,7 +27,7 @@ public class ServiceProxyFactory {
    * used to complete the request future with timeout exception in case no response comes from service.
    */
   private static final ScheduledExecutorService delayer =
-      ThreadFactory.singleScheduledExecutorService("sc-services-timeout");
+      ThreadFactory.newSingleScheduledExecutorService("sc-services-timeout");
 
   private RouterFactory routerFactory;
 

--- a/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
+++ b/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
@@ -2,8 +2,6 @@ package io.scalecube.transport;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -11,18 +9,17 @@ import java.util.concurrent.ScheduledExecutorService;
  * Used to create and cache shared thread pools with given name.
  */
 public class ThreadFactory {
-
-  private static final ConcurrentMap<String, ScheduledExecutorService> schedulers = new ConcurrentHashMap<>();
-
+  
   /**
    * Used to create and cache shared thread pools with given name.
    * 
    * @name the requested name of the single thread executor if not cached will be created.
    */
-  public static ScheduledExecutorService singleScheduledExecutorService(String name) {
+  public static ScheduledExecutorService newSingleScheduledExecutorService(String name) {
     String nameFormat = name.replaceAll("%", "%%");
-    return schedulers.computeIfAbsent(nameFormat, func -> compute(nameFormat));
+    return compute(nameFormat);
   }
+  
 
   private static ScheduledExecutorService compute(String name) {
     return Executors.newSingleThreadScheduledExecutor(

--- a/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
+++ b/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
@@ -1,5 +1,7 @@
 package io.scalecube.transport;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.concurrent.Executors;
@@ -16,6 +18,7 @@ public class ThreadFactory {
    * @name the requested name of the single thread executor if not cached will be created.
    */
   public static ScheduledExecutorService newSingleScheduledExecutorService(String name) {
+    checkArgument(name!=null, "name can't be null");
     String nameFormat = name.replaceAll("%", "%%");
     return compute(nameFormat);
   }

--- a/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
+++ b/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
@@ -11,18 +11,18 @@ import java.util.concurrent.ScheduledExecutorService;
  * Used to create and cache shared thread pools with given name.
  */
 public class ThreadFactory {
-  
+
   /**
    * Used to create and cache shared thread pools with given name.
    * 
    * @name the requested name of the single thread executor if not cached will be created.
    */
   public static ScheduledExecutorService newSingleScheduledExecutorService(String name) {
-    checkArgument(name!=null, "name can't be null");
+    checkArgument(name != null, "name can't be null");
     String nameFormat = name.replaceAll("%", "%%");
     return compute(nameFormat);
   }
-  
+
 
   private static ScheduledExecutorService compute(String name) {
     return Executors.newSingleThreadScheduledExecutor(

--- a/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
+++ b/transport/src/main/java/io/scalecube/transport/ThreadFactory.java
@@ -1,4 +1,4 @@
-package io.scalecube.services;
+package io.scalecube.transport;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -20,12 +20,12 @@ public class ThreadFactory {
    * @name the requested name of the single thread executor if not cached will be created.
    */
   public static ScheduledExecutorService singleScheduledExecutorService(String name) {
-    return schedulers.computeIfAbsent(name, func -> compute(name));
+    String nameFormat = name.replaceAll("%", "%%");
+    return schedulers.computeIfAbsent(nameFormat, func -> compute(nameFormat));
   }
 
   private static ScheduledExecutorService compute(String name) {
     return Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat(name).setDaemon(true).build());
   }
-
 }

--- a/transport/src/test/java/io/scalecube/transport/ThreadFactoryTest.java
+++ b/transport/src/test/java/io/scalecube/transport/ThreadFactoryTest.java
@@ -1,24 +1,30 @@
 package io.scalecube.transport;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import io.scalecube.testlib.BaseTest;
-import io.scalecube.transport.Address;
-import io.scalecube.transport.ThreadFactory;
 
 import org.junit.Test;
 
-public class ThreadFactoryTest extends BaseTest{
+public class ThreadFactoryTest extends BaseTest {
 
   @Test
-  public void test_ipv6_thread_factory_addressing(){
-    
+  public void test_ipv6_thread_factory_addressing() {
+
+    // verify issue: https://github.com/scalecube/scalecube/issues/171
     ThreadFactory factory = new ThreadFactory();
-    
+
     Address address = Address.create("/fe80:0:0:0:8cf6:f5c8:c946:2c30%eno1", 4001);
     String nameFormat = "sc-membership-" + address.toString();
     factory.newSingleScheduledExecutorService(nameFormat);
-
-    assertTrue(true); // if we reached here no IllegalFormatConversionException is thrown.
+    // if we reached here no IllegalFormatConversionException is thrown.
+    
+    try {
+      factory.newSingleScheduledExecutorService(null);
+    } catch (Exception ex) {
+      assertEquals("name can't be null", ex.getMessage().toString());
+    }
+    
+    
   }
 }

--- a/transport/src/test/java/io/scalecube/transport/ThreadFactoryTest.java
+++ b/transport/src/test/java/io/scalecube/transport/ThreadFactoryTest.java
@@ -1,4 +1,4 @@
-package io.scalecube.cluster.membership;
+package io.scalecube.transport;
 
 import static org.junit.Assert.assertTrue;
 
@@ -8,7 +8,7 @@ import io.scalecube.transport.ThreadFactory;
 
 import org.junit.Test;
 
-public class MembersipProtocolTest extends BaseTest{
+public class ThreadFactoryTest extends BaseTest{
 
   @Test
   public void test_ipv6_thread_factory_addressing(){


### PR DESCRIPTION
IllegalFormatConversionException

When starting Scalecube and one of the addresses only has an IPv6
address (for various reasons, in my case the DHCP didn't complete, but
we could really be using only an IPv6 network) then Addressing uses
NetworkInterface.getInetAddresses() to get an Inet6Address which looks
something like this: /fe80:0:0:0:8cf6:f5c8:c946:2c30%eno1.

Then when MembershipProtocol constructor tries to use the address to
create a "name format" for ThreadFactoryBuilder, the % in the address
causes the thread factory builder to crash with a
java.util.IllegalFormatConversionException when it tries to create
thread names using String.format().