### PR TITLE
@Inject microservices.

### DIFF
--- a/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
@@ -67,7 +67,6 @@ public class LocalServiceInstance implements ServiceInstance {
       }
       return result;
     } catch (Exception ex) {
-      ex.printStackTrace();
       return ex;
     }
   }

--- a/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/LocalServiceInstance.java
@@ -67,6 +67,7 @@ public class LocalServiceInstance implements ServiceInstance {
       }
       return result;
     } catch (Exception ex) {
+      ex.printStackTrace();
       return ex;
     }
   }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -5,9 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.scalecube.cluster.Cluster;
 import io.scalecube.cluster.ClusterConfig;
 import io.scalecube.services.annotations.AnnotationServiceProcessor;
-import io.scalecube.services.annotations.Inject;
 import io.scalecube.services.annotations.ServiceProcessor;
-import io.scalecube.services.annotations.ServiceProxy;
 import io.scalecube.services.routing.RoundRobinServiceRouter;
 import io.scalecube.services.routing.Router;
 import io.scalecube.transport.Address;
@@ -18,14 +16,12 @@ import io.scalecube.transport.TransportConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * The ScaleCube-Services module enables to provision and consuming microservices in a cluster. ScaleCube-Services

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -393,12 +393,15 @@ public class Microservices {
     if (field.isAnnotationPresent(ServiceProxy.class) && field.getType().isInterface()) {
       ServiceProxy annotation = field.getAnnotation(ServiceProxy.class);
       ProxyContext builder = this.proxy().api(field.getType());
-      if (annotation.router().equals(Router.class)) {
+      if (!annotation.router().equals(Router.class)) {
         builder.router(annotation.router());
-      } else if (annotation.timeout() > 0) {
+      } 
+      
+      if (annotation.timeout() > 0) {
         long nanos = annotation.timeUnit().toNanos(annotation.timeout());
         builder.timeout(Duration.ofNanos(nanos));
       }
+      
       field.setAccessible(true);
       field.set(service, builder.create());
     }

--- a/services/src/main/java/io/scalecube/services/ServiceInjector.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInjector.java
@@ -1,0 +1,108 @@
+package io.scalecube.services;
+
+import io.scalecube.services.Microservices.ProxyContext;
+import io.scalecube.services.annotations.Inject;
+import io.scalecube.services.annotations.Service;
+import io.scalecube.services.annotations.ServiceProxy;
+import io.scalecube.services.routing.Router;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.stream.Collectors;
+
+/**
+ * 
+ * Service Injector scan and injects beans to a given Microservices instance.
+ *
+ */
+public class ServiceInjector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceInjector.class);
+
+  /**
+   * Injector builder.
+   * 
+   * @param Microservices instance to be injected.
+   * @return Microservices after injection.
+   */
+  public static Builder builder(Microservices ms) {
+    return new Builder(ms);
+  }
+
+  static class Builder {
+
+    private Microservices microservices;
+
+    private Builder(Microservices ms) {
+      this.microservices = ms;
+    }
+
+    /**
+     * inject instances to the microservices instance. either Microservices or ServiceProxy.
+     * 
+     * @return injected microservices instance.
+     */
+    public Microservices inject() {
+      this.inject(this.microservices);
+      return this.microservices;
+    }
+
+    /**
+     * scan all local service instances and inject a service proxy.
+     */
+    void inject(Microservices ms) {
+      ms.services().stream()
+          .filter(instance -> instance.isLocal())
+          .collect(Collectors.toList()).forEach(instance -> {
+            scanServiceFields(((LocalServiceInstance) instance).serviceObject());
+          });
+    }
+
+    void scanServiceFields(Object service) {
+      for (Field field : service.getClass().getDeclaredFields()) {
+        injectField(field, service);
+      }
+    }
+
+    void injectField(Field field, Object service) {
+      if (field.isAnnotationPresent(Inject.class) && field.getType().equals(Microservices.class)) {
+        setField(field, service, this.microservices);
+      } else if (field.isAnnotationPresent(Inject.class) && isService(field)) {
+        setField(field, service, this.microservices.proxy().api(field.getType()).create());
+      } else if (field.isAnnotationPresent(ServiceProxy.class) && isService(field)) {
+        injectServiceProxy(field, service);
+      }
+    }
+
+    boolean isService(Field field) {
+      return field.getType().isAnnotationPresent(Service.class);
+    }
+
+    void injectServiceProxy(Field field, Object service) {
+      ServiceProxy annotation = field.getAnnotation(ServiceProxy.class);
+      ProxyContext builder = this.microservices.proxy().api(field.getType());
+      if (!annotation.router().equals(Router.class)) {
+        builder.router(annotation.router());
+      }
+      if (annotation.timeout() > 0) {
+        long nanos = annotation.timeUnit().toNanos(annotation.timeout());
+        builder.timeout(Duration.ofNanos(nanos));
+      }
+      setField(field, service, builder.create());
+    }
+
+    void setField(Field field, Object object, Object value) {
+      try {
+        field.setAccessible(true);
+        field.set(object, value);
+      } catch (Exception ex) {
+        LOGGER.error("failed to set service proxy of type: {} reason:{}", object.getClass().getName(), ex.getMessage());
+      }
+    }
+  }
+
+
+
+}

--- a/services/src/main/java/io/scalecube/services/ServiceInjector.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInjector.java
@@ -23,11 +23,11 @@ public class ServiceInjector {
   /**
    * Injector builder.
    * 
-   * @param Microservices instance to be injected.
-   * @return Microservices after injection.
+   * @param microservices instance to be injected.
+   * @return Builder for injection.
    */
-  public static Builder builder(Microservices ms) {
-    return new Builder(ms);
+  public static Builder builder(Microservices microservices) {
+    return new Builder(microservices);
   }
 
   static class Builder {
@@ -51,8 +51,8 @@ public class ServiceInjector {
     /**
      * scan all local service instances and inject a service proxy.
      */
-    private void inject(Microservices ms) {
-      ms.services().stream()
+    private void inject(Microservices microservices) {
+      microservices.services().stream()
           .filter(instance -> instance.isLocal())
           .collect(Collectors.toList()).forEach(instance -> {
             scanServiceFields(((LocalServiceInstance) instance).serviceObject());

--- a/services/src/main/java/io/scalecube/services/ServiceInjector.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInjector.java
@@ -51,7 +51,7 @@ public class ServiceInjector {
     /**
      * scan all local service instances and inject a service proxy.
      */
-    void inject(Microservices ms) {
+    private void inject(Microservices ms) {
       ms.services().stream()
           .filter(instance -> instance.isLocal())
           .collect(Collectors.toList()).forEach(instance -> {
@@ -59,13 +59,13 @@ public class ServiceInjector {
           });
     }
 
-    void scanServiceFields(Object service) {
+    private void scanServiceFields(Object service) {
       for (Field field : service.getClass().getDeclaredFields()) {
         injectField(field, service);
       }
     }
 
-    void injectField(Field field, Object service) {
+    private void injectField(Field field, Object service) {
       if (field.isAnnotationPresent(Inject.class) && field.getType().equals(Microservices.class)) {
         setField(field, service, this.microservices);
       } else if (field.isAnnotationPresent(Inject.class) && isService(field)) {
@@ -75,11 +75,11 @@ public class ServiceInjector {
       }
     }
 
-    boolean isService(Field field) {
+    private boolean isService(Field field) {
       return field.getType().isAnnotationPresent(Service.class);
     }
 
-    void injectServiceProxy(Field field, Object service) {
+    private void injectServiceProxy(Field field, Object service) {
       ServiceProxy annotation = field.getAnnotation(ServiceProxy.class);
       ProxyContext builder = this.microservices.proxy().api(field.getType());
       if (!annotation.router().equals(Router.class)) {
@@ -92,7 +92,7 @@ public class ServiceInjector {
       setField(field, service, builder.create());
     }
 
-    void setField(Field field, Object object, Object value) {
+    private void setField(Field field, Object object, Object value) {
       try {
         field.setAccessible(true);
         field.set(object, value);

--- a/services/src/main/java/io/scalecube/services/ServiceInjector.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInjector.java
@@ -14,7 +14,6 @@ import java.time.Duration;
 import java.util.stream.Collectors;
 
 /**
- * 
  * Service Injector scan and injects beans to a given Microservices instance.
  *
  */

--- a/services/src/main/java/io/scalecube/services/annotations/Inject.java
+++ b/services/src/main/java/io/scalecube/services/annotations/Inject.java
@@ -1,24 +1,14 @@
 package io.scalecube.services.annotations;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.concurrent.TimeUnit;
-
-import io.scalecube.services.routing.Router;
-
-import java.lang.annotation.ElementType;
 
 @Target(value = {ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
 @Retention(value = RetentionPolicy.RUNTIME)
 @Documented
-public @interface ServiceProxy {
-
-  Class<? extends Router> router() default Router.class;
-
-  int timeout() default 3;
-
-  TimeUnit timeUnit() default TimeUnit.SECONDS;
+public @interface Inject {
 
 }

--- a/services/src/main/java/io/scalecube/services/annotations/ServiceProxy.java
+++ b/services/src/main/java/io/scalecube/services/annotations/ServiceProxy.java
@@ -1,24 +1,39 @@
 package io.scalecube.services.annotations;
 
+import io.scalecube.services.routing.Router;
+
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
 
-import io.scalecube.services.routing.Router;
-
-import java.lang.annotation.ElementType;
 
 @Target(value = {ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
 @Retention(value = RetentionPolicy.RUNTIME)
 @Documented
 public @interface ServiceProxy {
 
+  /**
+   * Defines the router to be used when creating this proxy by default empty Router.
+   * 
+   * @return Router type.
+   */
   Class<? extends Router> router() default Router.class;
 
+  /**
+   * Timeout while waiting for response from remote service by default is 3 seconds.
+   * 
+   * @return the expected timeout.
+   */
   int timeout() default 3;
 
+  /**
+   * TimeUnit for the timeout by default TimeUnit.SECONDS.
+   * 
+   * @return time unit.
+   */
   TimeUnit timeUnit() default TimeUnit.SECONDS;
 
 }

--- a/services/src/test/java/io/scalecube/services/CoarseGrainedService.java
+++ b/services/src/test/java/io/scalecube/services/CoarseGrainedService.java
@@ -11,4 +11,10 @@ public interface CoarseGrainedService {
   @ServiceMethod
   public CompletableFuture<String> callGreeting(String name);
 
+  @ServiceMethod
+  public CompletableFuture<String> callGreetingTimeout(String request);
+
+  @ServiceMethod
+  public CompletableFuture<String> callGreetingWithDispatcher(String request);
+
 }

--- a/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
@@ -1,16 +1,27 @@
 package io.scalecube.services;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
+import io.scalecube.services.annotations.Inject;
 import io.scalecube.services.annotations.ServiceProxy;
+import io.scalecube.services.routing.RoundRobinServiceRouter;
 
 public class CoarseGrainedServiceImpl implements CoarseGrainedService {
 
-  @ServiceProxy
+  @ServiceProxy(router = RoundRobinServiceRouter.class)
   private GreetingService greetingService;
+
+  @Inject
+  private Microservices ms;
 
   @Override
   public CompletableFuture<String> callGreeting(String name) {
-    return this.greetingService.greeting(name);
+    if (ms != null) {
+      return this.greetingService.greeting(name);
+    } else {
+      return CompletableFuture.completedFuture("microservices is not set");
+    }
   }
+
 }

--- a/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
@@ -9,7 +9,7 @@ import io.scalecube.services.routing.RoundRobinServiceRouter;
 
 public class CoarseGrainedServiceImpl implements CoarseGrainedService {
 
-  @ServiceProxy(router = RoundRobinServiceRouter.class)
+  @ServiceProxy(router = RoundRobinServiceRouter.class, timeout = 3, timeUnit = TimeUnit.SECONDS)
   private GreetingService greetingService;
 
   @Inject

--- a/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
+++ b/services/src/test/java/io/scalecube/services/CoarseGrainedServiceImpl.java
@@ -1,15 +1,23 @@
 package io.scalecube.services;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-
 import io.scalecube.services.annotations.Inject;
 import io.scalecube.services.annotations.ServiceProxy;
 import io.scalecube.services.routing.RoundRobinServiceRouter;
 
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+
+
 public class CoarseGrainedServiceImpl implements CoarseGrainedService {
 
-  @ServiceProxy(router = RoundRobinServiceRouter.class, timeout = 3, timeUnit = TimeUnit.SECONDS)
+  public static final String SERVICE_NAME = "io.scalecube.services.GreetingService";
+
+  @ServiceProxy(router = RoundRobinServiceRouter.class, timeout = 1, timeUnit = TimeUnit.MILLISECONDS)
+  private GreetingService greetingServiceTimeout;
+
+  @Inject
   private GreetingService greetingService;
 
   @Inject
@@ -17,11 +25,33 @@ public class CoarseGrainedServiceImpl implements CoarseGrainedService {
 
   @Override
   public CompletableFuture<String> callGreeting(String name) {
-    if (ms != null) {
-      return this.greetingService.greeting(name);
-    } else {
-      return CompletableFuture.completedFuture("microservices is not set");
-    }
+    return this.greetingService.greeting(name);
   }
 
+  @Override
+  public CompletableFuture<String> callGreetingTimeout(String request) {
+    CompletableFuture<String> future = new CompletableFuture<String>();
+    this.greetingServiceTimeout.greetingRequestTimeout(new GreetingRequest(request, Duration.ofSeconds(2)))
+        .whenComplete((success, error) -> {
+          if (error != null) {
+            future.completeExceptionally(error);
+          } else {
+            future.complete(success.getResult());
+          }
+        });
+    return future;
+  }
+
+  @Override
+  public CompletableFuture<String> callGreetingWithDispatcher(String request) {
+    final CompletableFuture<String> future = new CompletableFuture<String>();
+
+    ServiceCall service = ms.dispatcher().create();
+    service.invoke(ServiceCall.request(SERVICE_NAME, "greeting")
+        .data("joe").build()).whenComplete((message, error) -> {
+          future.complete(message.data().toString());
+        });
+
+    return future;
+  }
 }


### PR DESCRIPTION
Enable to inject Microservices instance to the services.
- add Inject annotation for injecting instances that requires no special
params.

- fix the test to inject microservices and see its not null.
- add to service proxy the ability to statically set router and timeout.

```java
 @Inject
  private Microservices ms;

@Inject
  private GreetingService greetingService; // inject with default configuration

// inject with specific configuration.
  @ServiceProxy(router = RoundRobinServiceRouter.class, timeout = 3, timeUnit = TimeUnit.SECONDS)
  private GreetingService greetingService;
```

