### PR TITLE
enable the possibility to contribute to metadata and not replace

### DIFF
--- a/cluster/src/main/java/io/scalecube/cluster/ClusterConfig.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterConfig.java
@@ -231,6 +231,10 @@ public final class ClusterConfig implements FailureDetectorConfig, GossipConfig,
       return this;
     }
 
+    public Map<String, String> metadata() {
+      return this.metadata;
+    }
+    
     public Builder seedMembers(Address... seedMembers) {
       this.seedMembers = Arrays.asList(seedMembers);
       return this;
@@ -333,11 +337,5 @@ public final class ClusterConfig implements FailureDetectorConfig, GossipConfig,
       Preconditions.checkState(pingTimeout < pingInterval, "Ping timeout can't be bigger than ping interval");
       return new ClusterConfig(this);
     }
-
-    public Map<String, String> metadata() {
-      return this.metadata;
-    }
-
   }
-
 }

--- a/cluster/src/main/java/io/scalecube/cluster/ClusterConfig.java
+++ b/cluster/src/main/java/io/scalecube/cluster/ClusterConfig.java
@@ -334,6 +334,10 @@ public final class ClusterConfig implements FailureDetectorConfig, GossipConfig,
       return new ClusterConfig(this);
     }
 
+    public Map<String, String> metadata() {
+      return this.metadata;
+    }
+
   }
 
 }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -33,12 +33,14 @@ import java.util.concurrent.CompletableFuture;
  * compose. True isolation is achieved through shared-nothing design. This means the services in ScaleCube are
  * autonomous, loosely coupled and mobile (location transparent)—necessary requirements for resilence and elasticity
  * 
- * <p>ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
+ * <p>
+ * ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
  * build the service component itself. the Service component is simply java class that implements the service Interface
  * and ScaleCube take care for the rest of the magic. it derived and influenced by Actor model and reactive and
  * streaming patters but does not force application developers to it.
  * 
- * <p>ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
+ * <p>
+ * ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
  * <li>location transparency and discovery of service instances.</li>
  * <li>fault tolerance using gossip and failure detection.</li>
  * <li>share nothing - fully distributed and decentralized architecture.</li>
@@ -49,7 +51,8 @@ import java.util.concurrent.CompletableFuture;
  * <li>low latency</li>
  * <li>supports routing extensible strategies when selecting service end-points</li>
  * 
- * </p><b>basic usage example:</b>
+ * </p>
+ * <b>basic usage example:</b>
  * 
  * <pre>
  * 
@@ -188,17 +191,17 @@ public class Microservices {
         // create cluster and transport with given config.
         sender = new TransportServiceCommunicator(Transport.bindAwait(transportConfig));
       }
-      
+
       return ServiceInjector.builder(new Microservices(cluster, sender, servicesConfig)).inject();
     }
 
     private ClusterConfig getClusterConfig(ServicesConfig servicesConfig) {
       Map<String, String> metadata = clusterConfig.metadata();
-      
-      if(metadata.isEmpty()){
+
+      if (metadata.isEmpty()) {
         metadata = new HashMap<>();
       }
-      
+
       if (servicesConfig != null && !servicesConfig.services().isEmpty()) {
         metadata.putAll(Microservices.metadata(servicesConfig));
       }
@@ -241,11 +244,11 @@ public class Microservices {
 
       return this;
     }
-    
+
     public ServicesConfig.Builder services() {
       return ServicesConfig.builder(this);
     }
-    
+
     /**
      * Services list to be registered.
      * 
@@ -289,7 +292,7 @@ public class Microservices {
       this.router = routerType;
       return this;
     }
-    
+
     public Class<? extends Router> router() {
       return this.router;
     }
@@ -356,5 +359,5 @@ public class Microservices {
     return this.cluster.shutdown();
   }
 
-  
+
 }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -194,10 +194,8 @@ public class Microservices {
 
     private ClusterConfig getClusterConfig(ServicesConfig servicesConfig) {
       if (servicesConfig != null && !servicesConfig.services().isEmpty()) {
-        Map<String, String> metadata = clusterConfig.metadata();
-        if (metadata.isEmpty()) {
-          metadata = new HashMap<>();
-        }
+        Map<String, String> metadata = new HashMap<>();
+        metadata.putAll(clusterConfig.metadata());
         metadata.putAll(Microservices.metadata(servicesConfig));
         clusterConfig.metadata(metadata);
       }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -193,16 +193,15 @@ public class Microservices {
     }
 
     private ClusterConfig getClusterConfig(ServicesConfig servicesConfig) {
-      Map<String, String> metadata = clusterConfig.metadata();
-
-      if (metadata.isEmpty()) {
-        metadata = new HashMap<>();
-      }
-
       if (servicesConfig != null && !servicesConfig.services().isEmpty()) {
+        Map<String, String> metadata = clusterConfig.metadata();
+        if (metadata.isEmpty()) {
+          metadata = new HashMap<>();
+        }
         metadata.putAll(Microservices.metadata(servicesConfig));
+        clusterConfig.metadata(metadata);
       }
-      clusterConfig.metadata(metadata);
+
       return clusterConfig.build();
     }
 

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -202,7 +202,7 @@ public class Microservices {
       if (servicesConfig != null && !servicesConfig.services().isEmpty()) {
         metadata.putAll(Microservices.metadata(servicesConfig));
       }
-
+      clusterConfig.metadata(metadata);
       return clusterConfig.build();
     }
 

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -194,7 +194,11 @@ public class Microservices {
 
     private ClusterConfig getClusterConfig(ServicesConfig servicesConfig) {
       Map<String, String> metadata = clusterConfig.metadata();
-
+      
+      if(metadata.isEmpty()){
+        metadata = new HashMap<>();
+      }
+      
       if (servicesConfig != null && !servicesConfig.services().isEmpty()) {
         metadata.putAll(Microservices.metadata(servicesConfig));
       }

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -33,14 +33,12 @@ import java.util.concurrent.CompletableFuture;
  * compose. True isolation is achieved through shared-nothing design. This means the services in ScaleCube are
  * autonomous, loosely coupled and mobile (location transparent)—necessary requirements for resilence and elasticity
  * 
- * <p>
- * ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
+ * <p>ScaleCube services requires developers only to two simple Annotations declaring a Service but not regards how you
  * build the service component itself. the Service component is simply java class that implements the service Interface
  * and ScaleCube take care for the rest of the magic. it derived and influenced by Actor model and reactive and
  * streaming patters but does not force application developers to it.
  * 
- * <p>
- * ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
+ * <p>ScaleCube-Services is not yet-anther RPC system in the sense its is cluster aware to provide:
  * <li>location transparency and discovery of service instances.</li>
  * <li>fault tolerance using gossip and failure detection.</li>
  * <li>share nothing - fully distributed and decentralized architecture.</li>
@@ -51,8 +49,7 @@ import java.util.concurrent.CompletableFuture;
  * <li>low latency</li>
  * <li>supports routing extensible strategies when selecting service end-points</li>
  * 
- * </p>
- * <b>basic usage example:</b>
+ * </p><b>basic usage example:</b>
  * 
  * <pre>
  * 

--- a/services/src/main/java/io/scalecube/services/Microservices.java
+++ b/services/src/main/java/io/scalecube/services/Microservices.java
@@ -193,13 +193,11 @@ public class Microservices {
     }
 
     private ClusterConfig getClusterConfig(ServicesConfig servicesConfig) {
-      Map<String, String> metadata = new HashMap<>();
+      Map<String, String> metadata = clusterConfig.metadata();
 
       if (servicesConfig != null && !servicesConfig.services().isEmpty()) {
-        metadata = Microservices.metadata(servicesConfig);
+        metadata.putAll(Microservices.metadata(servicesConfig));
       }
-
-      clusterConfig.metadata(metadata);
 
       return clusterConfig.build();
     }

--- a/services/src/test/java/io/scalecube/services/ServiceTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import io.scalecube.cluster.ClusterConfig;
+import io.scalecube.cluster.ClusterConfig.Builder;
 import io.scalecube.services.a.b.testing.CanaryService;
 import io.scalecube.services.a.b.testing.CanaryTestingRouter;
 import io.scalecube.services.a.b.testing.GreetingServiceImplA;
@@ -15,6 +17,10 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -818,6 +824,19 @@ public class ServiceTest extends BaseTest {
     gateway.cluster().shutdown();
     services1.cluster().shutdown();
     services2.cluster().shutdown();
+  }
+
+  @Test
+  public void test_services_contribute_to_cluster_metadata() {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("HOSTNAME", "host1");
+    Builder clusterConfig = ClusterConfig.builder().metadata(metadata);
+    Microservices ms = Microservices.builder()
+        .clusterConfig(clusterConfig)
+        .services(new GreetingServiceImpl()).build();
+
+    assertTrue(ms.cluster().member().metadata().containsKey("HOSTNAME"));
+    assertTrue(ms.cluster().member().metadata().containsKey("io.scalecube.services.GreetingService:tags:"));
   }
 
   private GreetingService createProxy(Microservices gateway) {


### PR DESCRIPTION
enable the possibility to contribute to metadata and not replace user defined metata when using services

in current solution when using services it will override the cluster
metadata and will put the services metadata on top of the cluster
metadata

this change expose the metadata() accessor from the builder so
micoservices builder will just putAll metadata it has on top of the user
defined.