### PR TITLE
Consolidate dispatcher and proxy

### DIFF
--- a/cluster/src/main/java/io/scalecube/cluster/membership/IdGenerator.java
+++ b/cluster/src/main/java/io/scalecube/cluster/membership/IdGenerator.java
@@ -5,7 +5,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
-final class IdGenerator {
+public final class IdGenerator {
 
   private static final int DEFAULT_SIZE = 10;
 
@@ -43,6 +43,13 @@ final class IdGenerator {
     return generateId(length, ThreadLocalRandom.current());
   }
 
+  /**
+   * Generate id.
+   * 
+   * @param length of the id.
+   * @param random random factor.
+   * @return id as string.
+   */
   public static String generateId(int length, Random random) {
     byte[] buffer = new byte[length];
 

--- a/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/RemoteServiceInstance.java
@@ -8,13 +8,8 @@ import io.scalecube.transport.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
 
 public class RemoteServiceInstance implements ServiceInstance {
   private static final Logger LOGGER = LoggerFactory.getLogger(RemoteServiceInstance.class);
@@ -24,22 +19,18 @@ public class RemoteServiceInstance implements ServiceInstance {
   private final String serviceName;
   private final Map<String, String> tags;
   private final ServiceCommunicator sender;
-  
-  private ServiceRegistry serviceRegistry;
 
-  
 
   /**
    * Remote service instance constructor to initiate instance.
    * 
-   * @param serviceRegistry to be used for instance context.
+   * @param sender to be used for communication.
    * @param serviceReference service reference of this instance.
    * @param tags describing this service instance metadata.
    */
-  public RemoteServiceInstance(ServiceRegistry serviceRegistry, ServiceCommunicator sender,
+  public RemoteServiceInstance(ServiceCommunicator sender,
       ServiceReference serviceReference,
       Map<String, String> tags) {
-    this.serviceRegistry = serviceRegistry;
     this.serviceName = serviceReference.serviceName();
     this.address = serviceReference.address();
     this.memberId = serviceReference.memberId();
@@ -61,90 +52,41 @@ public class RemoteServiceInstance implements ServiceInstance {
    * @return CompletableFuture with dispatching result
    * @throws Exception in case of an error
    */
-  public CompletableFuture<Object> dispatch(Message request) throws Exception {
-    ServiceResponse responseFuture = new ServiceResponse(fn -> request);
-    Message requestMessage = composeRequest(request, responseFuture.correlationId());
-
-    // Resolve method
-    String methodName = request.header(ServiceHeaders.METHOD);
-    checkArgument(methodName != null, "Method name can't be null");
-
-    String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
-    checkArgument(serviceName != null, "Service request can't be null");
-
-    return futureInvoke(requestMessage, message -> message);
+  public CompletableFuture<Message> dispatch(Message request) throws Exception {
+    return invoke(request);
   }
 
   @Override
-  public Object invoke(Message request) throws Exception {
+  public CompletableFuture<Message> invoke(Message request) {
     checkArgument(request != null, "Service request can't be null");
+    CompletableFuture<Message> result = new CompletableFuture<Message>();
 
-    // Resolve method
-    String methodName = request.header(ServiceHeaders.METHOD);
+    futureInvoke(request)
+        .whenComplete((success, error) -> {
+          if (error == null) {
+            result.complete(Message.builder().data("remote send completed").build());
+          } else {
+            result.completeExceptionally(error);
+          }
+        });
+
+    return result;
+  }
+
+  private CompletableFuture<Void> futureInvoke(final Message request) {
+
+    final String methodName = request.header(ServiceHeaders.METHOD);
     checkArgument(methodName != null, "Method name can't be null");
-    ServiceDefinition definition = serviceRegistry.getServiceDefinition(serviceName).get();
-    Method method = definition.method(methodName);
-    checkArgument(method != null,
-        "Method '%s' is not registered for service: %s", methodName, definition.serviceInterface());
 
-    // Try to call via messaging
-    if (method.getReturnType().equals(CompletableFuture.class)) {
-      if (extractGenericReturnType(method).equals(Message.class)) {
-        return futureInvoke(request, message -> message);
-      } else {
-        return futureInvoke(request, Message::data);
-      }
-    } else if (method.getReturnType().equals(Void.TYPE)) {
-      return futureInvoke(request, message -> request.correlationId());
-    } else {
-      throw new UnsupportedOperationException("Unsupported return type for method: " + method);
-    }
-  }
+    final String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
+    checkArgument(serviceName != null, "Service request can't be null");
 
-  private Type extractGenericReturnType(Method method) {
-    Type type = method.getGenericReturnType();
-    if (type instanceof ParameterizedType) {
-      return ((ParameterizedType) type).getActualTypeArguments()[0];
-    } else {
-      return Object.class;
-    }
-  }
-
-  private CompletableFuture<Object> futureInvoke(final Message request, Function<Message, Object> fn) throws Exception {
-
-    ServiceResponse responseFuture = new ServiceResponse(fn);
-
-    Message requestMessage = composeRequest(request, responseFuture.correlationId());
-
-    CompletableFuture<Void> sendFuture = sendRemote(requestMessage);
-    // check that send operation completed successfully else report an error
-    sendFuture.whenComplete((success, error) -> {
-      if (error != null) {
-        LOGGER.debug("cid [{}] send remote service request message failed {} , error {}",
-            requestMessage.correlationId(),
-            requestMessage, error);
-
-        // if send future faild then complete the response future Exceptionally.
-        Optional<ServiceResponse> future = ServiceResponse.get(requestMessage.correlationId());
-        if (future.isPresent()) {
-          future.get().completeExceptionally(error);
-        }
-      }
-    });
-    return responseFuture.future();
+    return sendRemote(request);
   }
 
   private CompletableFuture<Void> sendRemote(Message requestMessage) {
     LOGGER.debug("cid [{}] send remote service request message {}", requestMessage.correlationId(), requestMessage);
     return this.sender.send(address, requestMessage);
-  }
-
-  private Message composeRequest(Message request, final String correlationId) {
-    return Message.withData(request.data())
-        .header(ServiceHeaders.SERVICE_REQUEST, serviceName)
-        .header(ServiceHeaders.METHOD, request.header(ServiceHeaders.METHOD))
-        .correlationId(correlationId)
-        .build();
   }
 
   @Override
@@ -172,4 +114,5 @@ public class RemoteServiceInstance implements ServiceInstance {
   public Map<String, String> tags() {
     return tags;
   }
+
 }

--- a/services/src/main/java/io/scalecube/services/ServiceCall.java
+++ b/services/src/main/java/io/scalecube/services/ServiceCall.java
@@ -1,5 +1,6 @@
 package io.scalecube.services;
 
+import io.scalecube.cluster.membership.IdGenerator;
 import io.scalecube.services.routing.Router;
 import io.scalecube.transport.Message;
 import io.scalecube.transport.Message.Builder;
@@ -10,20 +11,10 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class ServiceCall {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceProxyFactory.class);
-
-  /**
-   * used to complete the request future with timeout exception in case no response comes from service.
-   */
-  private static final ScheduledExecutorService delayer =
-      ThreadFactory.singleScheduledExecutorService("sc-services-timeout");
 
   private Duration timeout;
   private Router router;
@@ -33,7 +24,7 @@ public class ServiceCall {
     this.timeout = timeout;
   }
 
-  public <T> CompletableFuture<Message> invoke(Message message) {
+  public CompletableFuture<Message> invoke(Message message) {
     return invoke(message, timeout);
   }
 
@@ -47,28 +38,22 @@ public class ServiceCall {
    * @return CompletableFuture with service call dispatching result.
    * @throws Exception in case of an error or TimeoutException if no response if a given duration.
    */
-  public <T> CompletableFuture<Message> invoke(Message request, Duration timeout) {
+  public CompletableFuture<Message> invoke(Message request, Duration timeout) {
     String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
     String methodName = request.header(ServiceHeaders.METHOD);
-    try {
 
-      Optional<ServiceInstance> optionalServiceInstance = router.route(request);
+    Optional<ServiceInstance> optionalServiceInstance = router.route(request);
 
-      if (optionalServiceInstance.isPresent()) {
-        return this.invoke(request, optionalServiceInstance.get(), timeout);
-      } else {
-        LOGGER.error(
-            "Failed  to invoke service, No reachable member with such service definition [{}], args [{}]",
-            serviceName, request);
-        throw new IllegalStateException("No reachable member with such service: " + methodName);
-      }
-
-    } catch (Throwable ex) {
+    if (optionalServiceInstance.isPresent()) {
+      return this.invoke(request, optionalServiceInstance.get(), timeout);
+    } else {
       LOGGER.error(
-          "Failed  to invoke service, No reachable member with such service method [{}], args [{}], error [{}]",
-          methodName, request.data(), ex);
+          "Failed  to invoke service, No reachable member with such service definition [{}], args [{}]",
+          serviceName, request);
       throw new IllegalStateException("No reachable member with such service: " + methodName);
     }
+
+
   }
 
   /**
@@ -81,7 +66,7 @@ public class ServiceCall {
    * @return CompletableFuture with service call dispatching result.
    * @throws Exception in case of an error or TimeoutException if no response if a given duration.
    */
-  public <T> CompletableFuture<Message> invoke(Message request, ServiceInstance serviceInstance) throws Exception {
+  public CompletableFuture<Message> invoke(Message request, ServiceInstance serviceInstance) throws Exception {
     return invoke(request, serviceInstance, timeout);
   }
 
@@ -96,64 +81,29 @@ public class ServiceCall {
    * @return CompletableFuture with service call dispatching result.
    * @throws Exception in case of an error or TimeoutException if no response if a given duration.
    */
-  @SuppressWarnings("unchecked")
-  public <T> CompletableFuture<Message> invoke(Message request, ServiceInstance serviceInstance, Duration duration)
-      throws Exception {
+  public CompletableFuture<Message> invoke(final Message request, final ServiceInstance serviceInstance,
+      final Duration duration) {
 
-    if (serviceInstance.isLocal()) {
-      CompletableFuture<?> resultFuture = (CompletableFuture<?>) serviceInstance.invoke(request);
-      return (CompletableFuture<Message>) timeoutAfter(resultFuture, timeout)
-          .thenApply(result -> toMessage(request, (T) result));
-    } else {
-      RemoteServiceInstance remote = (RemoteServiceInstance) serviceInstance;
-      CompletableFuture<?> resultFuture =
-          (CompletableFuture<?>) remote.dispatch(request);
+    if (!serviceInstance.isLocal()) {
+      String cid = IdGenerator.generateId();
 
-      return (CompletableFuture<Message>) timeoutAfter(resultFuture, timeout);
-    }
-  }
+      Message requestMessage = asRequest(request, cid);
 
-  private <T> Message toMessage(Message request, T result) {
-    if (result instanceof Message) {
-      return (Message) result;
-    } else {
-      return Message.builder()
-          .header(ServiceHeaders.SERVICE_RESPONSE, request.header(ServiceHeaders.SERVICE_REQUEST))
-          .header(ServiceHeaders.METHOD, request.header(ServiceHeaders.METHOD))
-          .correlationId(request.correlationId())
-          .qualifier(request.qualifier())
-          .data(result)
-          .build();
-    }
-  }
+      final ServiceResponse responseFuture = ServiceResponse.correlationId(cid);
 
-  private CompletableFuture<?> timeoutAfter(final CompletableFuture<?> resultFuture, Duration timeout) {
-
-    final CompletableFuture<Class<Void>> timeoutFuture = new CompletableFuture<>();
-
-    // schedule to terminate the target goal in future in case it was not done yet
-    final ScheduledFuture<?> scheduledEvent = delayer.schedule(() -> {
-      // by this time the target goal should have finished.
-      if (!resultFuture.isDone()) {
-        // target goal not finished in time so cancel it with timeout.
-        resultFuture.completeExceptionally(new TimeoutException("expecting response reached timeout!"));
-      }
-    }, timeout.toMillis(), TimeUnit.MILLISECONDS);
-
-    // cancel the timeout in case target goal did finish on time
-    if (resultFuture != null) {
-      resultFuture.thenRun(() -> {
-        if (resultFuture.isDone()) {
-          if (!scheduledEvent.isDone()) {
-            scheduledEvent.cancel(false);
-          }
-          timeoutFuture.complete(Void.TYPE);
+      serviceInstance.invoke(requestMessage).whenComplete((success, error) -> {
+        if (error == null) {
+          responseFuture.withTimeout(duration);
+        } else {
+          responseFuture.completeExceptionally(error);
         }
       });
+
+      return responseFuture.future();
     } else {
-      return CompletableFuture.completedFuture(null);
+      return serviceInstance.invoke(request);
     }
-    return resultFuture;
+
   }
 
   /**
@@ -168,5 +118,13 @@ public class ServiceCall {
         .header(ServiceHeaders.SERVICE_REQUEST, serviceName)
         .header(ServiceHeaders.METHOD, methodName);
 
+  }
+
+  private Message asRequest(Message request, final String correlationId) {
+    return Message.withData(request.data())
+        .header(ServiceHeaders.SERVICE_REQUEST, request.header(ServiceHeaders.SERVICE_REQUEST))
+        .header(ServiceHeaders.METHOD, request.header(ServiceHeaders.METHOD))
+        .correlationId(correlationId)
+        .build();
   }
 }

--- a/services/src/main/java/io/scalecube/services/ServiceHeaders.java
+++ b/services/src/main/java/io/scalecube/services/ServiceHeaders.java
@@ -13,11 +13,6 @@ public final class ServiceHeaders {
    */
   public static final String METHOD = "m";
 
-  /**
-   * This header is supposed to be used by application in case when registering a service at discovery. the service
-   * header is used to mark this registration as a microservice instance.
-   */
-  public static final String SERVICE = "service";
 
   /**
    * This header is supposed to be used by application in case when sending service request. the service-request header
@@ -40,13 +35,6 @@ public final class ServiceHeaders {
    */
   public static String serviceMethod(Message request) {
     return request.header(METHOD);
-  }
-
-  /**
-   * Extract header value from a given message. header is used to mark this registration as a microservice instance.
-   */
-  public static String service(Message request) {
-    return request.header(SERVICE);
   }
 
   /**

--- a/services/src/main/java/io/scalecube/services/ServiceInjector.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInjector.java
@@ -10,6 +10,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.stream.Collectors;
 
@@ -102,6 +105,19 @@ public class ServiceInjector {
     }
   }
 
-
+  /**
+   * extract parameterized return value of a method.
+   * 
+   * @param method to extract type from.
+   * @return the generic type of the return value or object.
+   */
+  public static Type extractParameterizedReturnType(Method method) {
+    Type type = method.getGenericReturnType();
+    if (type instanceof ParameterizedType) {
+      return ((ParameterizedType) type).getActualTypeArguments()[0];
+    } else {
+      return Object.class;
+    }
+  }
 
 }

--- a/services/src/main/java/io/scalecube/services/ServiceInstance.java
+++ b/services/src/main/java/io/scalecube/services/ServiceInstance.java
@@ -4,12 +4,13 @@ import io.scalecube.transport.Address;
 import io.scalecube.transport.Message;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public interface ServiceInstance {
 
   String serviceName();
 
-  Object invoke(Message request) throws Exception;
+  CompletableFuture<Message> invoke(Message request) ;
 
   String memberId();
 

--- a/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
@@ -97,7 +97,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
           LOGGER.debug("Member: {} is {} : {}", member, type, serviceRef);
           if (type.equals(DiscoveryType.ADDED) || type.equals(DiscoveryType.DISCOVERED)) {
             serviceInstances.putIfAbsent(serviceRef,
-                new RemoteServiceInstance(this, sender, serviceRef, info.getTags()));
+                new RemoteServiceInstance(sender, serviceRef, info.getTags()));
           } else if (type.equals(DiscoveryType.REMOVED)) {
             serviceInstances.remove(serviceRef);
           }

--- a/services/src/main/java/io/scalecube/services/ThreadFactory.java
+++ b/services/src/main/java/io/scalecube/services/ThreadFactory.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ScheduledExecutorService;
 public class ThreadFactory {
 
   private static final ConcurrentMap<String, ScheduledExecutorService> schedulers = new ConcurrentHashMap<>();
+  public static String SC_SERVICES_TIMEOUT = "sc-services-timeout";
 
   /**
    * Used to create and cache shared thread pools with given name.

--- a/services/src/main/java/io/scalecube/services/TransportServiceCommunicator.java
+++ b/services/src/main/java/io/scalecube/services/TransportServiceCommunicator.java
@@ -21,9 +21,9 @@ public class TransportServiceCommunicator implements ServiceCommunicator {
 
   @Override
   public CompletableFuture<Void> send(Address address, Message message) {
-    CompletableFuture<Void> messageFuture = new CompletableFuture<>();
-    transport.send(address, message, messageFuture);
-    return messageFuture;
+    CompletableFuture<Void> future = new CompletableFuture<Void>();
+    transport.send(address, message, future);
+    return future;
   }
 
   @Override

--- a/services/src/main/java/io/scalecube/services/routing/RoundRobinServiceRouter.java
+++ b/services/src/main/java/io/scalecube/services/routing/RoundRobinServiceRouter.java
@@ -30,15 +30,18 @@ public class RoundRobinServiceRouter implements Router {
 
     String serviceName = request.header(ServiceHeaders.SERVICE_REQUEST);
     List<ServiceInstance> serviceInstances = serviceRegistry.serviceLookup(serviceName);
-    if (!serviceInstances.isEmpty()) {
+    if (serviceInstances.size() > 1) {
       AtomicInteger counter = counterByServiceName
           .computeIfAbsent(serviceName, or -> new AtomicInteger());
       int index = counter.incrementAndGet() % serviceInstances.size();
       return Optional.of(serviceInstances.get(index));
+    } else if (serviceInstances.size() == 1) {
+      return Optional.of(serviceInstances.get(0));
     } else {
       LOGGER.warn("route selection return null since no service instance was found for {}", serviceName);
       return Optional.empty();
     }
+
   }
 
 }

--- a/services/src/test/java/io/scalecube/services/ClusterServiceCommunicatorTest.java
+++ b/services/src/test/java/io/scalecube/services/ClusterServiceCommunicatorTest.java
@@ -56,6 +56,8 @@ public class ClusterServiceCommunicatorTest {
     service.greeting("joe").whenComplete((result, error) -> {
       if (error == null) {
         latch.countDown();
+      } else {
+        System.out.println("test_reuse_cluster_sender failed:  " + error);
       }
     });
 

--- a/services/src/test/java/io/scalecube/services/DispatchingFutureTest.java
+++ b/services/src/test/java/io/scalecube/services/DispatchingFutureTest.java
@@ -3,6 +3,7 @@ package io.scalecube.services;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import io.scalecube.cluster.membership.IdGenerator;
 import io.scalecube.transport.Message;
 
 import org.junit.Test;
@@ -18,9 +19,7 @@ public class DispatchingFutureTest {
   public void test_dispatching_future() throws Exception {
 
     Microservices member = Microservices.builder().build();
-    ServiceResponse response = new ServiceResponse(fn -> {
-      return null;
-    });
+    ServiceResponse response = ServiceResponse.correlationId(IdGenerator.generateId());
 
     Message request = Message.builder().correlationId(response.correlationId())
         .header(ServiceHeaders.SERVICE_RESPONSE, "").build();
@@ -50,9 +49,7 @@ public class DispatchingFutureTest {
   public void test_dispatching_future_error() throws Exception {
 
     Microservices member = Microservices.builder().build();
-    ServiceResponse response = new ServiceResponse(fn -> {
-      return null;
-    });
+    ServiceResponse response = ServiceResponse.correlationId(IdGenerator.generateId());
 
     Message request = Message.builder().correlationId(response.correlationId())
         .header(ServiceHeaders.SERVICE_RESPONSE, "").build();
@@ -83,9 +80,7 @@ public class DispatchingFutureTest {
   public void test_dispatching_future_completeExceptionally() throws Exception {
 
     Microservices member = Microservices.builder().build();
-    ServiceResponse response = new ServiceResponse(fn -> {
-      return null;
-    });
+    ServiceResponse response = ServiceResponse.correlationId(IdGenerator.generateId());
 
     Message request = Message.builder().correlationId(response.correlationId())
         .header(ServiceHeaders.SERVICE_RESPONSE, "").build();

--- a/services/src/test/java/io/scalecube/services/ServiceCallTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceCallTest.java
@@ -532,7 +532,7 @@ public class ServiceCallTest extends BaseTest {
 
     // Init params
     int warmUpCount = 1_000;
-    int count = 10_000;
+    int count = 100_000;
     CountDownLatch warmUpLatch = new CountDownLatch(warmUpCount);
 
     // Warm up

--- a/services/src/test/java/io/scalecube/services/ServiceHeadersTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceHeadersTest.java
@@ -14,12 +14,10 @@ public class ServiceHeadersTest {
   @Test
   public void test_ServiceHeaders() {
     Message request = Message.builder().header(ServiceHeaders.METHOD, "m")
-        .header(ServiceHeaders.SERVICE, "s")
         .header(ServiceHeaders.SERVICE_REQUEST, "req")
         .header(ServiceHeaders.SERVICE_RESPONSE, "res").build();
 
     assertEquals(ServiceHeaders.serviceMethod(request), "m");
-    assertEquals(ServiceHeaders.service(request), "s");
     assertEquals(ServiceHeaders.serviceRequest(request), "req");
     assertEquals(ServiceHeaders.serviceResponse(request), "res");
 

--- a/services/src/test/java/io/scalecube/services/ServiceInstanceTest.java
+++ b/services/src/test/java/io/scalecube/services/ServiceInstanceTest.java
@@ -77,7 +77,7 @@ public class ServiceInstanceTest {
     ServiceRegistry registry = new ServiceRegistryImpl(member.cluster(), sender, config, processor);
 
     RemoteServiceInstance instance =
-        new RemoteServiceInstance(registry, sender, reference, new HashMap<>());
+        new RemoteServiceInstance(sender, reference, new HashMap<>());
 
     assertEquals(instance.toString(), "RemoteServiceInstance [address=localhost:4000, memberId=a]");
     assertTrue(instance.tags().isEmpty());
@@ -89,7 +89,7 @@ public class ServiceInstanceTest {
     try {
       instance.dispatch(Message.builder()
           .header(ServiceHeaders.METHOD, null)
-          .header(ServiceHeaders.SERVICE, "s")
+          .header(ServiceHeaders.SERVICE_REQUEST, "s")
           .build());
     } catch (Exception ex) {
       assertEquals(ex.toString(), "java.lang.IllegalArgumentException: Method name can't be null");
@@ -98,7 +98,7 @@ public class ServiceInstanceTest {
     try {
       instance.invoke(Message.builder()
           .header(ServiceHeaders.METHOD, "unkonwn")
-          .header(ServiceHeaders.SERVICE, "s")
+          .header(ServiceHeaders.SERVICE_REQUEST, "s")
           .build());
     } catch (Exception ex) {
       assertEquals(ex.toString(), "java.util.NoSuchElementException: No value present");
@@ -107,7 +107,7 @@ public class ServiceInstanceTest {
     try {
       instance.dispatch(Message.builder()
           .header(ServiceHeaders.METHOD, "m")
-          .header(ServiceHeaders.SERVICE, null)
+          .header(ServiceHeaders.SERVICE_REQUEST, null)
           .build());
     } catch (Exception ex) {
       assertEquals(ex.toString(), "java.lang.IllegalArgumentException: Service request can't be null");


### PR DESCRIPTION
both service proxy to use service call as single method to invoke services
- refactor services layer to use service call so proxy is just a wrapper that translate from java api to service messages.
- remove the use of generics and better handle timeouts.
- use IdGenerator to create corrlation ids insted of UUID that is expensive.