### PR TITLE
check if service reference exists before trying to put and log it.

### DIFF
--- a/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
@@ -101,7 +101,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
             }
           } else if (type.equals(DiscoveryType.REMOVED)) {
             serviceInstances.remove(serviceRef);
-            LOGGER.info("Service Reference was REMOVED since Member {} have left the cluster {} : {}", member,
+            LOGGER.info("Service Reference was REMOVED since Member have left the cluster {} : {}", member,
                 serviceRef);
           }
         });

--- a/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
@@ -96,7 +96,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
             if (!serviceInstances.containsKey(serviceRef)) {
               serviceInstances.putIfAbsent(serviceRef,
                   new RemoteServiceInstance(sender, serviceRef, info.getTags()));
-              LOGGER.info("Service Reference was ADDED since new Member {} has joined the cluster {} : {}", member,
+              LOGGER.info("Service Reference was ADDED since new Member has joined the cluster {} : {}", member,
                   serviceRef);
             }
           } else if (type.equals(DiscoveryType.REMOVED)) {

--- a/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
+++ b/services/src/main/java/io/scalecube/services/ServiceRegistryImpl.java
@@ -93,10 +93,12 @@ public class ServiceRegistryImpl implements ServiceRegistry {
 
           LOGGER.debug("Member: {} is {} : {}", member, type, serviceRef);
           if (type.equals(DiscoveryType.ADDED) || type.equals(DiscoveryType.DISCOVERED)) {
-            serviceInstances.putIfAbsent(serviceRef,
-                new RemoteServiceInstance(sender, serviceRef, info.getTags()));
-            LOGGER.info("Service Reference was ADDED since new Member {} has joined the cluster {} : {}", member,
-                serviceRef);
+            if (!serviceInstances.containsKey(serviceRef)) {
+              serviceInstances.putIfAbsent(serviceRef,
+                  new RemoteServiceInstance(sender, serviceRef, info.getTags()));
+              LOGGER.info("Service Reference was ADDED since new Member {} has joined the cluster {} : {}", member,
+                  serviceRef);
+            }
           } else if (type.equals(DiscoveryType.REMOVED)) {
             serviceInstances.remove(serviceRef);
             LOGGER.info("Service Reference was REMOVED since Member {} have left the cluster {} : {}", member,


### PR DESCRIPTION
check if service reference exists before trying to put and log it.
this should reduce the amount of time logs are created when trying to
reload cluster services.