### PR TITLE
Fix client disconnection [streams]

### DIFF
--- a/streams/src/main/java/io/scalecube/streams/DefaultStreamProcessor.java
+++ b/streams/src/main/java/io/scalecube/streams/DefaultStreamProcessor.java
@@ -77,7 +77,9 @@ public final class DefaultStreamProcessor implements StreamProcessor {
       // connection logic: connection lost => observer error
       subscriptions.add(
           eventStream.listenChannelContextClosed()
+              .filter(event -> event.getAddress().equals(channelContext.getAddress()))
               .map(event -> new IOException("ChannelContext closed on address: " + event.getAddress()))
+
               .subscribe(emitter::onError));
 
     }, Emitter.BackpressureMode.BUFFER);

--- a/streams/src/main/java/io/scalecube/streams/StreamProcessors.java
+++ b/streams/src/main/java/io/scalecube/streams/StreamProcessors.java
@@ -165,6 +165,10 @@ public final class StreamProcessors {
       return serverStreamProcessorFactory.listenServerStreamProcessor();
     }
 
+    public void accept(Consumer<StreamProcessor> onStreamProcessor) {
+      serverStreamProcessorFactory.listenServerStreamProcessor().subscribe(onStreamProcessor::accept);
+    }
+
     public void close() {
       listeningServerStream.close();
       serverStreamProcessorFactory.close();

--- a/streams/src/test/java/io/scalecube/streams/ClientStreamTest.java
+++ b/streams/src/test/java/io/scalecube/streams/ClientStreamTest.java
@@ -2,10 +2,7 @@ package io.scalecube.streams;
 
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import io.scalecube.streams.Event.Topic;
 import io.scalecube.transport.Address;
@@ -36,7 +33,7 @@ public class ClientStreamTest {
       ListeningServerStream.newListeningServerStream().withListenAddress("localhost");
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     clientStream = ClientStream.newClientStream();
     address = serverStream.bindAwait();
   }


### PR DESCRIPTION
When 2 client streams are connected to ServerStreamProcessor, and one of them disconnects, the second client also gets disconnection event (which is invalid)

add handy method to StreamProcessors