### PR TITLE
Fixed bug in ClientStream (and hence in NettyClientTransport)

### DIFF
--- a/streams/src/main/java/io/scalecube/streams/ChannelContext.java
+++ b/streams/src/main/java/io/scalecube/streams/ChannelContext.java
@@ -118,7 +118,7 @@ public final class ChannelContext {
   }
 
   public void postReadSuccess(StreamMessage message) {
-    onNext(Event.ReadSuccess(address).identity(id).message(message).build());
+    onNext(Event.readSuccess(address).identity(id).message(message).build());
   }
 
   public void postReadError(Throwable throwable) {
@@ -161,6 +161,8 @@ public final class ChannelContext {
 
   @Override
   public String toString() {
-    return "ChannelContext{id=" + id + ", address=" + address + "}";
+    return "ChannelContext [id=" + id
+        + ", address=" + address
+        + "]";
   }
 }

--- a/streams/src/main/java/io/scalecube/streams/ChannelContext.java
+++ b/streams/src/main/java/io/scalecube/streams/ChannelContext.java
@@ -1,7 +1,5 @@
 package io.scalecube.streams;
 
-import static io.scalecube.streams.Event.Topic;
-
 import io.scalecube.cluster.membership.IdGenerator;
 import io.scalecube.transport.Address;
 
@@ -120,23 +118,23 @@ public final class ChannelContext {
   }
 
   public void postReadSuccess(StreamMessage message) {
-    onNext(new Event.Builder(Topic.ReadSuccess, address, id).message(message).build());
+    onNext(Event.ReadSuccess(address).identity(id).message(message).build());
   }
 
   public void postReadError(Throwable throwable) {
-    onNext(new Event.Builder(Topic.ReadError, address, id).error(throwable).build());
+    onNext(Event.readError(address).identity(id).error(throwable).build());
   }
 
   public void postWrite(StreamMessage message) {
-    onNext(new Event.Builder(Topic.Write, address, id).message(message).build());
+    onNext(Event.write(address).identity(id).message(message).build());
   }
 
   public void postWriteError(StreamMessage message, Throwable throwable) {
-    onNext(new Event.Builder(Topic.WriteError, address, id).error(throwable).message(message).build());
+    onNext(Event.writeError(address).identity(id).error(throwable).message(message).build());
   }
 
   public void postWriteSuccess(StreamMessage message) {
-    onNext(new Event.Builder(Topic.WriteSuccess, address, id).message(message).build());
+    onNext(Event.writeSuccess(address).identity(id).message(message).build());
   }
 
   /**

--- a/streams/src/main/java/io/scalecube/streams/DefaultEventStream.java
+++ b/streams/src/main/java/io/scalecube/streams/DefaultEventStream.java
@@ -1,7 +1,5 @@
 package io.scalecube.streams;
 
-import static io.scalecube.streams.Event.Topic;
-
 import io.scalecube.transport.Address;
 
 import rx.Observable;
@@ -53,6 +51,11 @@ public class DefaultEventStream implements EventStream {
   }
 
   @Override
+  public void onNext(Event event) {
+    subject.onNext(event);
+  }
+
+  @Override
   public void onNext(Address address, Event event) {
     Stream<ChannelContext> channelContextStream = subscriptions.keySet().stream();
     channelContextStream.filter(ctx -> ctx.getAddress().equals(address)).forEach(ctx -> ctx.onNext(event));
@@ -86,14 +89,14 @@ public class DefaultEventStream implements EventStream {
   }
 
   private void onChannelContextClosed(ChannelContext ctx) {
-    subject.onNext(new Event.Builder(Topic.ChannelContextClosed, ctx.getAddress(), ctx.getId()).build());
+    subject.onNext(Event.channelContextClosed(ctx.getAddress()).identity(ctx.getId()).build());
   }
 
   private void onChannelContextSubscribed(ChannelContext ctx) {
-    subject.onNext(new Event.Builder(Topic.ChannelContextSubscribed, ctx.getAddress(), ctx.getId()).build());
+    subject.onNext(Event.channelContextSubscribed(ctx.getAddress()).identity(ctx.getId()).build());
   }
 
   private void onChannelContextUnsubscribed(ChannelContext ctx) {
-    subject.onNext(new Event.Builder(Topic.ChannelContextUnsubscribed, ctx.getAddress(), ctx.getId()).build());
+    subject.onNext(Event.channelContextUnsubscribed(ctx.getAddress()).identity(ctx.getId()).build());
   }
 }

--- a/streams/src/main/java/io/scalecube/streams/DefaultStreamProcessor.java
+++ b/streams/src/main/java/io/scalecube/streams/DefaultStreamProcessor.java
@@ -77,7 +77,8 @@ public final class DefaultStreamProcessor implements StreamProcessor {
       // connection logic: connection lost => observer error
       subscriptions.add(
           eventStream.listenChannelContextClosed()
-              .subscribe(event -> onChannelContextClosed(event, emitter)));
+              .map(event -> new IOException("ChannelContext closed on address: " + event.getAddress()))
+              .subscribe(emitter::onError));
 
     }, Emitter.BackpressureMode.BUFFER);
   }
@@ -102,10 +103,5 @@ public final class DefaultStreamProcessor implements StreamProcessor {
       return;
     }
     emitter.onNext(message); // remote => normal response
-  }
-
-  private void onChannelContextClosed(Event event, Observer<StreamMessage> emitter) {
-    // Hint: at this point 'event' contains ClientStream's ChannelContext (i.e. remote one) where close() was emitted
-    emitter.onError(new IOException("ChannelContext closed on address: " + event.getAddress()));
   }
 }

--- a/streams/src/main/java/io/scalecube/streams/Event.java
+++ b/streams/src/main/java/io/scalecube/streams/Event.java
@@ -44,7 +44,7 @@ public final class Event {
     return new Builder(other);
   }
 
-  public static Builder ReadSuccess(Address address) {
+  public static Builder readSuccess(Address address) {
     return new Event.Builder(Topic.ReadSuccess).address(address);
   }
 
@@ -144,13 +144,12 @@ public final class Event {
 
   @Override
   public String toString() {
-    return "Event{" +
-        "topic=" + topic +
-        ", address=" + address +
-        ", identity='" + identity + '\'' +
-        ", message=" + message +
-        ", error=" + error +
-        '}';
+    return "Event [topic=" + topic
+        + ", address=" + address
+        + ", identity=" + identity
+        + ", message=" + message.orElse(null)
+        + ", error=" + error.orElse(null) +
+        "]";
   }
 
   //// Builder

--- a/streams/src/main/java/io/scalecube/streams/Event.java
+++ b/streams/src/main/java/io/scalecube/streams/Event.java
@@ -2,6 +2,7 @@ package io.scalecube.streams;
 
 import io.scalecube.transport.Address;
 
+import java.util.Objects;
 import java.util.Optional;
 
 public final class Event {
@@ -41,6 +42,38 @@ public final class Event {
 
   public static Builder copyFrom(Event other) {
     return new Builder(other);
+  }
+
+  public static Builder ReadSuccess(Address address) {
+    return new Event.Builder(Topic.ReadSuccess).address(address);
+  }
+
+  public static Builder readError(Address address) {
+    return new Event.Builder(Topic.ReadError).address(address);
+  }
+
+  public static Builder write(Address address) {
+    return new Event.Builder(Topic.Write).address(address);
+  }
+
+  public static Builder writeSuccess(Address address) {
+    return new Event.Builder(Topic.WriteSuccess).address(address);
+  }
+
+  public static Builder writeError(Address address) {
+    return new Event.Builder(Topic.WriteError).address(address);
+  }
+
+  public static Builder channelContextClosed(Address address) {
+    return new Event.Builder(Topic.ChannelContextClosed).address(address);
+  }
+
+  public static Builder channelContextSubscribed(Address address) {
+    return new Event.Builder(Topic.ChannelContextSubscribed).address(address);
+  }
+
+  public static Builder channelContextUnsubscribed(Address address) {
+    return new Event.Builder(Topic.ChannelContextUnsubscribed).address(address);
   }
 
   //// Getters
@@ -109,26 +142,47 @@ public final class Event {
     return topic == Topic.ChannelContextUnsubscribed;
   }
 
+  @Override
+  public String toString() {
+    return "Event{" +
+        "topic=" + topic +
+        ", address=" + address +
+        ", identity='" + identity + '\'' +
+        ", message=" + message +
+        ", error=" + error +
+        '}';
+  }
+
   //// Builder
 
   public static class Builder {
 
-    private final Topic topic; // not null
-    private final Address address; // not null
-    private final String identity; // not null
+    private Topic topic; // not null
+    private Address address; // not null
+    private String identity; // not null
     private StreamMessage message; // nullable
     private Throwable error; // nullable
 
-    public Builder(Topic topic, Address address, String identity) {
+    private Builder(Topic topic) {
       this.topic = topic;
-      this.address = address;
-      this.identity = identity;
     }
 
-    public Builder(Event other) {
-      this(other.topic, other.address, other.identity);
+    private Builder(Event other) {
+      this(other.topic);
+      this.address = other.address;
+      this.identity = other.identity;
       this.message = other.message.orElse(null);
       this.error = other.error.orElse(null);
+    }
+
+    public Builder address(Address address) {
+      this.address = address;
+      return this;
+    }
+
+    public Builder identity(String identity) {
+      this.identity = identity;
+      return this;
     }
 
     public Builder message(StreamMessage message) {
@@ -142,6 +196,9 @@ public final class Event {
     }
 
     public Event build() {
+      Objects.requireNonNull(topic);
+      Objects.requireNonNull(address);
+      Objects.requireNonNull(identity);
       return new Event(this);
     }
   }

--- a/streams/src/main/java/io/scalecube/streams/Event.java
+++ b/streams/src/main/java/io/scalecube/streams/Event.java
@@ -148,8 +148,8 @@ public final class Event {
         + ", address=" + address
         + ", identity=" + identity
         + ", message=" + message.orElse(null)
-        + ", error=" + error.orElse(null) +
-        "]";
+        + ", error=" + error.orElse(null)
+        + "]";
   }
 
   //// Builder

--- a/streams/src/main/java/io/scalecube/streams/EventStream.java
+++ b/streams/src/main/java/io/scalecube/streams/EventStream.java
@@ -12,6 +12,8 @@ public interface EventStream {
 
   Observable<Event> listen();
 
+  void onNext(Event event);
+
   void onNext(Address address, Event event);
 
   void close();

--- a/streams/src/main/java/io/scalecube/streams/ListeningServerStream.java
+++ b/streams/src/main/java/io/scalecube/streams/ListeningServerStream.java
@@ -92,6 +92,11 @@ public final class ListeningServerStream implements EventStream {
   }
 
   @Override
+  public void onNext(Event event) {
+    serverStream.onNext(event);
+  }
+
+  @Override
   public void onNext(Address address, Event event) {
     serverStream.onNext(address, event);
   }

--- a/streams/src/main/java/io/scalecube/streams/Qualifier.java
+++ b/streams/src/main/java/io/scalecube/streams/Qualifier.java
@@ -101,9 +101,4 @@ public final class Qualifier {
   public int hashCode() {
     return Objects.hash(stringValue);
   }
-
-  @Override
-  public String toString() {
-    return stringValue;
-  }
 }

--- a/streams/src/main/java/io/scalecube/streams/StreamMessage.java
+++ b/streams/src/main/java/io/scalecube/streams/StreamMessage.java
@@ -80,7 +80,7 @@ public final class StreamMessage {
 
   @Override
   public String toString() {
-    return "Message [q=" + qualifier
+    return "StreamMessage [q=" + qualifier
         + ", subject=" + subject
         + ", data=" + prepareDataString()
         + "]";

--- a/streams/src/main/java/io/scalecube/streams/netty/ChannelContextHandler.java
+++ b/streams/src/main/java/io/scalecube/streams/netty/ChannelContextHandler.java
@@ -26,14 +26,12 @@ public final class ChannelContextHandler extends ChannelDuplexHandler {
     Channel channel = ctx.channel();
     Attribute<ChannelContext> attribute = channel.attr(ChannelSupport.CHANNEL_CTX_ATTR_KEY);
     if (attribute.get() == null) {
+
       InetSocketAddress remoteAddress = (InetSocketAddress) ctx.channel().remoteAddress();
       String host = remoteAddress.getAddress().getHostAddress();
       int port = remoteAddress.getPort();
       ChannelContext channelContext = ChannelContext.create(Address.create(host, port));
       attribute.set(channelContext); // set channel attribute
-
-      // bind channelContext
-      channelContextConsumer.accept(channelContext);
 
       // register cleanup process upfront
       channelContext.listenClose(input -> {
@@ -44,6 +42,9 @@ public final class ChannelContextHandler extends ChannelDuplexHandler {
 
       // fire event to complete registration
       channel.pipeline().fireUserEventTriggered(ChannelSupport.CHANNEL_CTX_CREATED_EVENT);
+
+      // bind channelContext
+      channelContextConsumer.accept(channelContext);
     }
     super.channelActive(ctx);
   }

--- a/streams/src/main/java/io/scalecube/streams/netty/NettyClientTransport.java
+++ b/streams/src/main/java/io/scalecube/streams/netty/NettyClientTransport.java
@@ -4,17 +4,17 @@ import io.scalecube.streams.ChannelContext;
 import io.scalecube.transport.Address;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 
 import rx.Observable;
-import rx.subjects.ReplaySubject;
-import rx.subjects.Subject;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+import rx.subjects.AsyncSubject;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public final class NettyClientTransport {
@@ -30,59 +30,63 @@ public final class NettyClientTransport {
 
   /**
    * Async connect to remote address or retrieve existing connection.
-   * 
+   *
    * @param address address to connect to.
-   * @param consumer biConsumer with optional channelContext and optional Throwable.
    */
-  public void getOrConnect(Address address, BiConsumer<ChannelContext, Throwable> consumer) {
+  public CompletableFuture<ChannelContext> getOrConnect(Address address) {
+    CompletableFuture<ChannelContext> promise = new CompletableFuture<>();
     Observable<ChannelContext> observable = outboundChannels.computeIfAbsent(address, this::connect);
-    observable.subscribe(
-        channelContext -> { // register cleanup process upfront
-          channelContext.listenClose(input -> outboundChannels.remove(address, observable));
-          consumer.accept(channelContext, null);
-        },
-        throwable -> { // clean map right away
-          outboundChannels.remove(address, observable);
-          consumer.accept(null, throwable);
-        },
-        () -> { // no-op
-        });
+    observable.subscribe(promise::complete, promise::completeExceptionally);
+    return promise;
   }
 
   private Observable<ChannelContext> connect(Address address) {
-    Subject<ChannelContext, ChannelContext> subject = ReplaySubject.<ChannelContext>create().toSerialized();
-
-    ChannelFuture connectFuture = bootstrap.connect(address.host(), address.port());
-    connectFuture.addListener((ChannelFutureListener) channelFuture -> {
-      Channel channel = channelFuture.channel();
-      if (!channelFuture.isSuccess()) {
-        subject.onError(channelFuture.cause());
-        return;
+    AsyncSubject<ChannelContext> subject = AsyncSubject.create();
+    ChannelFuture channelFuture = bootstrap.connect(address.host(), address.port());
+    channelFuture.addListener((ChannelFutureListener) future -> {
+      Throwable error = future.cause(); // nullable
+      if (future.isSuccess()) {
+        // Hint: this line would activate code in ChannelContextHandler and eventually in NettyStreamMessageHandler;
+        // this is done to properly setup netty channel and pin channelContext to it
+        future.channel().pipeline().fireChannelActive();
+        try {
+          ChannelContext channelContext = ChannelSupport.getChannelContextOrThrow(future.channel());
+          // register cleanup process upfront
+          channelContext.listenClose(input -> outboundChannels.remove(address));
+          // emit channel context
+          subject.onNext(channelContext);
+          subject.onCompleted();
+        } catch (Exception throwable) {
+          error = throwable;
+        }
       }
-      // this line pins channelContext to netty channel
-      channel.pipeline().fireChannelActive();
-      try {
-        // try get channelContext and complete
-        subject.onNext(ChannelSupport.getChannelContextOrThrow(channel));
-        subject.onCompleted();
-      } catch (Exception throwable) {
-        subject.onError(throwable);
+      if (error != null) {
+        outboundChannels.remove(address);
+        subject.onError(future.cause());
       }
     });
-
-    return subject;
+    Scheduler scheduler = Schedulers.from(channelFuture.channel().eventLoop());
+    return subject.subscribeOn(scheduler);
   }
 
   /**
-   * Disconnect all channels.
+   * Close all netty channels.
    */
   public void close() {
-    // close all channels
+    // close all channel contexts (there by close all netty channels eventually)
     for (Address address : outboundChannels.keySet()) {
-      Observable<ChannelContext> observable = outboundChannels.remove(address);
+      Observable<ChannelContext> observable = outboundChannels.get(address);
       if (observable != null) {
-        observable.subscribe(ChannelContext::close);
+        observable.subscribe(
+            ChannelContext::close,
+            throwable -> {
+              // Hint: this method is left no-op intentionally
+            },
+            () -> {
+              // Hint: this method is left no-op intentionally
+            });
       }
     }
+    outboundChannels.clear();
   }
 }

--- a/streams/src/test/java/io/scalecube/streams/ClientStreamProcessorTest.java
+++ b/streams/src/test/java/io/scalecube/streams/ClientStreamProcessorTest.java
@@ -1,7 +1,6 @@
 package io.scalecube.streams;
 
 import static io.scalecube.streams.StreamMessage.from;
-import static org.junit.Assert.assertTrue;
 
 import io.scalecube.transport.Address;
 
@@ -110,7 +109,6 @@ public class ClientStreamProcessorTest {
     } finally {
       streamProcessor.close();
     }
-    assertTrue("codacy", true);
   }
 
   @Test
@@ -126,7 +124,6 @@ public class ClientStreamProcessorTest {
     } finally {
       streamProcessor.close();
     }
-    assertTrue("codacy", true);
   }
 
   @Test
@@ -142,7 +139,6 @@ public class ClientStreamProcessorTest {
     } finally {
       streamProcessor.close();
     }
-    assertTrue("codacy", true);
   }
 
   @Test
@@ -158,7 +154,6 @@ public class ClientStreamProcessorTest {
     } finally {
       streamProcessor.close();
     }
-    assertTrue("codacy", true);
   }
 
   @Test
@@ -175,7 +170,6 @@ public class ClientStreamProcessorTest {
     } finally {
       streamProcessor.close();
     }
-    assertTrue("codacy", true);
   }
 
   @Test
@@ -203,6 +197,5 @@ public class ClientStreamProcessorTest {
     } finally {
       streamProcessor.close();
     }
-    assertTrue("codacy", true);
   }
 }

--- a/streams/src/test/java/io/scalecube/streams/ClientStreamTest.java
+++ b/streams/src/test/java/io/scalecube/streams/ClientStreamTest.java
@@ -68,7 +68,7 @@ public class ClientStreamTest {
     clientStream.listen().subscribe(clientSubject);
     AssertableSubscriber<Event> clientSubscriber = clientSubject.test();
 
-    int n = (int) 1e5;
+    int n = (int) 1e4;
     IntStream.rangeClosed(1, n)
         .forEach(i -> clientStream.send(address, StreamMessage.builder().qualifier("q/" + i).build()));
 
@@ -91,7 +91,7 @@ public class ClientStreamTest {
     serverStream.listen().subscribe(serverSubject);
     AssertableSubscriber<Event> serverSubscriber = serverSubject.test();
 
-    int n = (int) 1e5;
+    int n = (int) 1e4;
     IntStream.rangeClosed(1, n)
         .forEach(i -> clientStream.send(address, StreamMessage.builder().qualifier("q/" + i).build()));
 
@@ -117,7 +117,7 @@ public class ClientStreamTest {
     clientStream.listen().filter(Event::isReadSuccess).subscribe(clientSubject);
     AssertableSubscriber<Event> clientSubscriber = clientSubject.test();
 
-    int n = (int) 1e5;
+    int n = (int) 1e4;
     IntStream.rangeClosed(1, n)
         .forEach(i -> clientStream.send(address, StreamMessage.builder().qualifier("q/" + i).build()));
 

--- a/streams/src/test/java/io/scalecube/streams/DefaultEventStreamTest.java
+++ b/streams/src/test/java/io/scalecube/streams/DefaultEventStreamTest.java
@@ -41,7 +41,6 @@ public class DefaultEventStreamTest {
     anotherCtx.postReadSuccess(messageTwo);
 
     subscriber.assertValueCount(6);
-    assertTrue("codacy", true);
   }
 
   @Test


### PR DESCRIPTION
**Updates**
- Fixed bug causing improper message ordering at simple sequential `ClientStream.send()` at really big message number - 10k, 100k messages; it had been reproducing simply from test code from main thread (reproduced by sending sequentially really big number, like 10k or more).
- Fixed stupid workaround in `ClientStream.send()` at branch where connection can't be established => we dont' have `ChannelContext` object and need somehow post `write_error` event; put beautiful elegant fix by adding new method `EventStream.onNext(Event)`; checked by unit test.

**What was learned**
- It took two days for me to put lines 68-69 in `NettyClientTransport`; this is what makes msg ordering work IN CONJUNCTION with async connect. 